### PR TITLE
add config field for the dashboard url

### DIFF
--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Public/CognitiveVRSettings.h
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Public/CognitiveVRSettings.h
@@ -28,7 +28,7 @@ class UCognitiveVRSettings
 		FString SessionViewer = "viewer.cognitive3d.com/scene/";
 
 	UPROPERTY(config, EditAnywhere, Category = CognitiveVR)
-		FString Dashboard = "https://app.cognitive3d.com/";
+		FString Dashboard = "app.cognitive3d.com/";
 
 	/** The number of player snapshots that will be collected together before being sent to analytics server and scene explorer*/
 	UPROPERTY(config, EditAnywhere, Category = "Cognitive_VR_Data\|Gaze")

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Public/CognitiveVRSettings.h
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Public/CognitiveVRSettings.h
@@ -27,6 +27,9 @@ class UCognitiveVRSettings
 	UPROPERTY(config, EditAnywhere, Category = CognitiveVR)
 		FString SessionViewer = "viewer.cognitive3d.com/scene/";
 
+	UPROPERTY(config, EditAnywhere, Category = CognitiveVR)
+		FString Dashboard = "https://app.cognitive3d.com/";
+
 	/** The number of player snapshots that will be collected together before being sent to analytics server and scene explorer*/
 	UPROPERTY(config, EditAnywhere, Category = "Cognitive_VR_Data\|Gaze")
 		int32 GazeBatchSize = 64;

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveVREditorModule.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveVREditorModule.cpp
@@ -76,8 +76,10 @@ public:
 			GLog->Log("CognitiveVRModule::StartupModule write defaults to ini");
 			FString defaultgateway = "data.cognitive3d.com";
 			FString defaultsessionviewer = "viewer.cognitive3d.com/scene/";
+			FString defaultdashboard = "https://app.cognitive3d.com";
 			GConfig->SetString(TEXT("/Script/CognitiveVR.CognitiveVRSettings"), TEXT("Gateway"), *defaultgateway, EngineIni);
 			GConfig->SetString(TEXT("/Script/CognitiveVR.CognitiveVRSettings"), TEXT("SessionViewer"), *defaultsessionviewer, EngineIni);
+			GConfig->SetString(TEXT("/Script/CognitiveVR.CognitiveVRSettings"), TEXT("Dashboard"), *defaultsessionviewer, EngineIni);
 
 			GConfig->SetInt(TEXT("/Script/CognitiveVR.CognitiveVRSettings"), TEXT("GazeBatchSize"), 64, EngineIni);
 

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveVREditorModule.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveVREditorModule.cpp
@@ -76,10 +76,10 @@ public:
 			GLog->Log("CognitiveVRModule::StartupModule write defaults to ini");
 			FString defaultgateway = "data.cognitive3d.com";
 			FString defaultsessionviewer = "viewer.cognitive3d.com/scene/";
-			FString defaultdashboard = "https://app.cognitive3d.com";
+			FString defaultdashboard = "app.cognitive3d.com";
 			GConfig->SetString(TEXT("/Script/CognitiveVR.CognitiveVRSettings"), TEXT("Gateway"), *defaultgateway, EngineIni);
 			GConfig->SetString(TEXT("/Script/CognitiveVR.CognitiveVRSettings"), TEXT("SessionViewer"), *defaultsessionviewer, EngineIni);
-			GConfig->SetString(TEXT("/Script/CognitiveVR.CognitiveVRSettings"), TEXT("Dashboard"), *defaultsessionviewer, EngineIni);
+			GConfig->SetString(TEXT("/Script/CognitiveVR.CognitiveVRSettings"), TEXT("Dashboard"), *defaultdashboard, EngineIni);
 
 			GConfig->SetInt(TEXT("/Script/CognitiveVR.CognitiveVRSettings"), TEXT("GazeBatchSize"), 64, EngineIni);
 

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/SSceneSetupWidget.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/SSceneSetupWidget.cpp
@@ -1064,7 +1064,7 @@ void SSceneSetupWidget::Construct(const FArguments& Args)
 					.HAlign(HAlign_Center)
 					.Visibility(this, &SSceneSetupWidget::IsUploadComplete)
 					.Text(FText::FromString("Open Dashboard"))
-					.OnClicked_Raw(FCognitiveEditorTools::GetInstance(), &FCognitiveEditorTools::OpenURL, FString("https://app.cognitive3d.com"))
+					.OnClicked_Raw(FCognitiveEditorTools::GetInstance(), &FCognitiveEditorTools::OpenURL, "https://" + FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/CognitiveVR.CognitiveVRSettings", "Dashboard", false))
 				]
 			]
 			+ SVerticalBox::Slot()


### PR DESCRIPTION
This PR is to fix a bug on the final page of the **Cognitive Scene Setup** dialog. If the project has a custom dashboard URL, the _Open Dashboard_ button does not navigate to custom URL. 

![image](https://user-images.githubusercontent.com/9155105/64898265-b3d8e600-d643-11e9-8361-a92db62c1325.png)

Side note: I'd preferred to place the full URL in the config file but there appears
to be a UE4 where part of the URL tail is dropped if the protocol is
specified. e.g. https://app.xyz.com/ -> https:

@calderarchinuk 