### PR TITLE
Fix fixation startup

### DIFF
--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Private/FixationRecorder.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Private/FixationRecorder.cpp
@@ -64,10 +64,7 @@ int32 UFixationRecorder::GetIndex(int32 offset)
 void UFixationRecorder::BeginPlay()
 {
 	if (HasBegunPlay()) { return; }
-
 	Super::BeginPlay();
-	instance = this;
-	world = GetWorld();
 }
 
 void UFixationRecorder::BeginSession()
@@ -1243,6 +1240,18 @@ float UFixationRecorder::GetDPIScale()
 
 UFixationRecorder* UFixationRecorder::GetFixationRecorder()
 {
+	if (instance == NULL)
+	{
+		for (TObjectIterator<UFixationRecorder> Itr; Itr; ++Itr)
+		{
+			UWorld* tempWorld = Itr->GetWorld();
+			if (tempWorld == NULL) { continue; }
+			if (tempWorld->WorldType != EWorldType::PIE && tempWorld->WorldType != EWorldType::Game) { continue; } //editor world. skip
+			instance = *Itr;
+			instance->world = tempWorld;
+			break;
+		}
+	}
 	return instance;
 }
 

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Private/FixationRecorder.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Private/FixationRecorder.cpp
@@ -451,23 +451,10 @@ int64 UFixationRecorder::GetEyeCaptureTimestamp()
 #elif defined OPENXR_EYETRACKING
 bool UFixationRecorder::AreEyesClosed()
 {
-	if (!eyeTracker.IsValid()) { return true; }
-	EEyeTrackerStatus status = eyeTracker->GetEyeTrackerStatus();
-	if (status != EEyeTrackerStatus::Tracking) { return true; }
-
-	if (eyeTracker->IsStereoGazeDataAvailable())
-	{
-		FEyeTrackerStereoGazeData stereoGazeData;
-		eyeTracker->GetEyeTrackerStereoGazeData(stereoGazeData);
-	}
-	else
-	{
-		FEyeTrackerGazeData gazeData;
-		eyeTracker->GetEyeTrackerGazeData(gazeData);
-	}
-
+	IEyeTracker const* const ET = GEngine ? GEngine->EyeTrackingDevice.Get() : nullptr;
+	if (ET == NULL) { return false; }
 	FEyeTrackerGazeData gazeData;
-	eyeTracker->GetEyeTrackerGazeData(gazeData);
+	ET->GetEyeTrackerGazeData(gazeData);
 	if (gazeData.ConfidenceValue < 0.5f)
 	{
 		return true;

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Private/FixationRecorder.h
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Private/FixationRecorder.h
@@ -82,8 +82,6 @@ private:
 	bool AreEyesClosed(TSharedPtr<ITobiiEyeTracker, ESPMode::ThreadSafe> eyetracker);
 	int64 GetEyeCaptureTimestamp(TSharedPtr<ITobiiEyeTracker, ESPMode::ThreadSafe> eyetracker);
 #elif defined OPENXR_EYETRACKING
-	IEyeTrackerModule& eyeTrackingModule = IEyeTrackerModule::Get();
-	TSharedPtr< class IEyeTracker, ESPMode::ThreadSafe > eyeTracker;
 	bool AreEyesClosed();
 	int64 GetEyeCaptureTimestamp();
 #elif defined SRANIPAL_1_2_API

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Private/PlayerTracker.h
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Private/PlayerTracker.h
@@ -80,10 +80,6 @@ private:
 	void TickSensors1000MS();
 	void TickSensors100MS();
 #endif
-#if defined OPENXR_EYETRACKING
-	IEyeTrackerModule& eyeTrackingModule = IEyeTrackerModule::Get();
-	TSharedPtr< class IEyeTracker, ESPMode::ThreadSafe > eyeTracker;
-#endif
 
 public:
 


### PR DESCRIPTION
# Description

Changed GetFixationRecorder code to search for a Fixation Recorder component, instead of calling in BeginPlay (which was too late from a session starting immediately).

Removed caching EyeTracker reference - null at start, making it invalid when running in a build.

Height Task ID (If applicable): T-709 (partially)

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] Any dependent changes have been merged and published in downstream modules