### PR TITLE
separated omnicept sensor callback handlers

### DIFF
--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Private/PlayerTracker.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Private/PlayerTracker.cpp
@@ -42,8 +42,8 @@ void UPlayerTracker::BeginPlay()
 		Super::BeginPlay();
 		GEngine->GetAllLocalPlayerControllers(controllers);
 #if defined HPGLIA_API
-		cog->GetWorld()->GetGameInstance()->GetTimerManager().SetTimer(AutoSendHandle, this, &UPlayerTracker::TickSensors1000MS, 1, true);
-		cog->GetWorld()->GetGameInstance()->GetTimerManager().SetTimer(AutoSendHandle, this, &UPlayerTracker::TickSensors100MS, 0.1, true);
+		cog->GetWorld()->GetGameInstance()->GetTimerManager().SetTimer(AutoSend1000MSHandle, this, &UPlayerTracker::TickSensors1000MS, 1, true);
+		cog->GetWorld()->GetGameInstance()->GetTimerManager().SetTimer(AutoSend100MSHandle, this, &UPlayerTracker::TickSensors100MS, 0.1, true);
 #endif
 	}
 	else

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Private/PlayerTracker.h
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Private/PlayerTracker.h
@@ -76,7 +76,8 @@ private:
 	float LastCognitiveLoad = -1;
 	float LastLeftPupilDiamter = -1;
 	float LastRightPupilDiamter = -1;
-	FTimerHandle AutoSendHandle;
+	FTimerHandle AutoSend1000MSHandle;
+	FTimerHandle AutoSend100MSHandle;
 	void TickSensors1000MS();
 	void TickSensors100MS();
 #endif


### PR DESCRIPTION
# Description

The two callbacks for Omnicept sensors were using the same handler, which caused 1000MS sensors to not be called.

Height Task ID (If applicable):

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] Any dependent changes have been merged and published in downstream modules