### PR TITLE
Skeletal mesh export fix

### DIFF
--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/CognitiveVR.Build.cs
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/CognitiveVR.Build.cs
@@ -22,9 +22,7 @@ namespace UnrealBuildTool.Rules
 				new string[] {
 					"CognitiveVR/Private",
                     "CognitiveVR/Public",
-					"CognitiveVR/Private/util",
-					System.IO.Path.GetFullPath(Target.RelativeEnginePath) + "/Source/Editor/Blutility/Private",
-					System.IO.Path.GetFullPath(Target.RelativeEnginePath) + "/Source/Developer/MeshUtilities/Private"
+					"CognitiveVR/Private/util"
 					// ... add other private include paths required here ...
 				}
 				);
@@ -53,13 +51,7 @@ namespace UnrealBuildTool.Rules
                     "JsonUtilities",
 					"UMG",
 					"EngineSettings",
-					"EyeTracker",
-					"Blutility",
-					"UnrealEd",
-					"AssetTools",
-					"SceneOutliner",
-					"EditorScriptingUtilities",
-					"MeshUtilities"
+					"EyeTracker"
 				}
 				);
 

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/CognitiveVR.Build.cs
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/CognitiveVR.Build.cs
@@ -22,7 +22,9 @@ namespace UnrealBuildTool.Rules
 				new string[] {
 					"CognitiveVR/Private",
                     "CognitiveVR/Public",
-					"CognitiveVR/Private/util"
+					"CognitiveVR/Private/util",
+					System.IO.Path.GetFullPath(Target.RelativeEnginePath) + "/Source/Editor/Blutility/Private",
+					System.IO.Path.GetFullPath(Target.RelativeEnginePath) + "/Source/Developer/MeshUtilities/Private"
 					// ... add other private include paths required here ...
 				}
 				);
@@ -51,7 +53,13 @@ namespace UnrealBuildTool.Rules
                     "JsonUtilities",
 					"UMG",
 					"EngineSettings",
-					"EyeTracker"
+					"EyeTracker",
+					"Blutility",
+					"UnrealEd",
+					"AssetTools",
+					"SceneOutliner",
+					"EditorScriptingUtilities",
+					"MeshUtilities"
 				}
 				);
 

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Private/DynamicObject.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Private/DynamicObject.cpp
@@ -125,10 +125,10 @@ void UDynamicObject::TryGenerateMeshName()
 		UActorComponent* actorSkeletalComponent = GetOwner()->GetComponentByClass(USkeletalMeshComponent::StaticClass());
 		if (actorSkeletalComponent != NULL)
 		{
-			USkeletalMeshComponent* staticmeshComponent = Cast<USkeletalMeshComponent>(actorSkeletalComponent);
-			if (staticmeshComponent != NULL && staticmeshComponent->SkeletalMesh != NULL)
+			USkeletalMeshComponent* skeletalmeshComponent = Cast<USkeletalMeshComponent>(actorSkeletalComponent);
+			if (skeletalmeshComponent != NULL && skeletalmeshComponent->SkeletalMesh != NULL)
 			{
-				MeshName = staticmeshComponent->GetName();
+				MeshName = skeletalmeshComponent->SkeletalMesh->GetName();
 			}
 		}
 	}

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/CognitiveVREditor.Build.cs
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/CognitiveVREditor.Build.cs
@@ -12,7 +12,9 @@ public class CognitiveVREditor : ModuleRules
                 "CognitiveVR/Private",
                 "CognitiveVR/Private/api",
                 "CognitiveVR/Private/network",
-                "CognitiveVR/Private/util"
+                "CognitiveVR/Private/util",
+                System.IO.Path.GetFullPath(Target.RelativeEnginePath) + "/Source/Editor/Blutility/Private",
+                System.IO.Path.GetFullPath(Target.RelativeEnginePath) + "/Source/Developer/MeshUtilities/Private"
             });
 
 
@@ -23,7 +25,13 @@ public class CognitiveVREditor : ModuleRules
 				"HTTP",
 				"Json",
 				"JsonUtilities",
-				"MaterialBaking"
+				"MaterialBaking",
+                "Blutility",
+                "UnrealEd",
+                "AssetTools",
+                "SceneOutliner",
+                "EditorScriptingUtilities",
+                "MeshUtilities"
             });
 
         PrivateDependencyModuleNames.AddRange(

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.cpp
@@ -1,7 +1,10 @@
 
+
 #include "CognitiveEditorTools.h"
 
 #define LOCTEXT_NAMESPACE "BaseToolEditor"
+
+
 
 //TSharedRef<FCognitiveEditorTools> ToolsInstance;
 FCognitiveEditorTools* FCognitiveEditorTools::CognitiveEditorToolsInstance;
@@ -393,6 +396,7 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 		TArray<UActorComponent*> actorSkeletalComponents;
 		exportObjects[i]->GetOwner()->GetComponents(USkeletalMeshComponent::StaticClass(), actorSkeletalComponents);
 		TArray< USkeletalMeshComponent*> skeletalMeshes;
+		TArray<UMeshComponent*> meshComponentsFromSkel;
 		for (int32 j = 0; j < actorSkeletalComponents.Num(); j++)
 		{
 			USkeletalMeshComponent* mesh = Cast<USkeletalMeshComponent>(actorSkeletalComponents[j]);
@@ -409,6 +413,7 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 			}
 
 			skeletalMeshes.Add(mesh);
+			meshComponentsFromSkel.Add(mesh);
 		}
 
 		DynamicMeshNames.Add(exportObjects[i]->MeshName);
@@ -444,14 +449,97 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 			PlatformFile.CreateDirectory(*justDirectory);
 		}
 
+		//after confirming the meshes and creating the directories, select this actor we are iterating on and increment actors exported for later
 		GEditor->SelectActor(exportObjects[i]->GetOwner(), true, false, true);
 		ActorsExported++;
+
+		/*
+			check if skeletal mesh, if so:
+			duplicate the actor with the skeletal mesh
+			newly duplicated actor will be selected only
+			convert new actor skeletal mesh to static mesh
+		*/
+
+		TArray<FAssetData> TempStaticMeshes;
+
+		if (skeletalMeshes.Num() > 0)
+		{
+			//get the selected actor that we will duplicate
+			USelection* SelectedActors = GEditor->GetSelectedActors();
+			TArray<AActor*> ActorObjs;
+			SelectedActors->GetSelectedObjects(ActorObjs);
+
+			//duplicate the selected actor
+			GEditor->edactDuplicateSelected(ActorObjs[0]->GetLevel(), false);
+
+			//UE selects only the duplicated actor after duplication
+
+			SelectedActors = GEditor->GetSelectedActors();
+			SelectedActors->GetSelectedObjects(ActorObjs);
+
+			FString message = "Number of objects selected after duplication: " + FString::FromInt(ActorObjs.Num()) + " " + ActorObjs[0]->GetName();
+			UE_LOG(LogTemp, Warning, TEXT("%s"), *message);
+
+			//setup temp meshes package
+			UPackage* NewPackageName = CreatePackage(TEXT("/Game/TempMesh"));
+
+			//take the static meshes that we set up earlier and use them to create a static mesh
+			UStaticMesh* tmpStatMesh = MeshUtilities.ConvertMeshesToStaticMesh(meshComponentsFromSkel, exportObjects[i]->GetOwner()->GetTransform(), NewPackageName->GetName());
+
+			FString message2 = "created static mesh out of skeletal meshes: " + tmpStatMesh->GetName();
+			UE_LOG(LogTemp, Warning, TEXT("%s"), *message2);
+
+			//create a new static mesh component for the currently selected actor
+			FName NewCompName = TEXT("StaticMeshComponent");
+			UStaticMeshComponent* NewComp = NewObject<UStaticMeshComponent>(ActorObjs[0], NewCompName);
+			//register the component, attach it to the root component of the actor, and set the static mesh
+			NewComp->RegisterComponent();
+			NewComp->AttachToComponent(exportObjects[i]->GetAttachParent(), FAttachmentTransformRules::KeepRelativeTransform);
+			NewComp->SetStaticMesh(tmpStatMesh);
+			//get the children of the skeletal mesh component and prepare to move them over to the new static mesh component
+			TArray<USceneComponent*> childrenToBeMoved;
+			USkeletalMeshComponent* skelToBeRemoved = ActorObjs[0]->FindComponentByClass<USkeletalMeshComponent>();
+			skelToBeRemoved->GetChildrenComponents(true, childrenToBeMoved);
+			for (int k = 0; k < childrenToBeMoved.Num(); k++)
+			{
+				//make sure we do not move our newly created static mesh component
+				if (childrenToBeMoved[k]->GetName() != NewCompName.ToString())
+				{
+					childrenToBeMoved[k]->AttachToComponent(NewComp, FAttachmentTransformRules::KeepRelativeTransform);
+					FString message3 = "reattached component: " + childrenToBeMoved[k]->GetName() + " to: " + NewComp->GetName();
+					UE_LOG(LogTemp, Warning, TEXT("%s"), *message3);
+				}
+			}
+			//delete the skeletal mesh component
+			skelToBeRemoved->DestroyComponent(false);
+			//save the meshes for deletion later
+			TempStaticMeshes.Add(tmpStatMesh);
+		}
+
+		
 
 		//export to obj skips skeletal fbx?
 		GLog->Log("FCognitiveEditorTools::ExportDynamicObjectArray dynamic output directory " + tempObject);
 
+		//exports the currently selected actor(s)
 		GUnrealEd->ExportMap(GWorld, *tempObject, true);
 		//FEditorFileUtils::Export(true);
+
+		//after export, if skeletal mesh, clean up duplicate actor
+		if (skeletalMeshes.Num() > 0)
+		{
+			GUnrealEd->edactDeleteSelected(GWorld, false, false, false);
+
+			//clean up static mesh
+			if (TempStaticMeshes.Num() > 0)
+			{
+				ObjectTools::DeleteAssets(TempStaticMeshes, false);
+			}
+			
+		}
+
+		
+		
 
 		exportObjects[i]->GetOwner()->SetActorLocation(originalLocation);
 		exportObjects[i]->GetOwner()->SetActorRotation(originalRotation);

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.cpp
@@ -477,8 +477,6 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 			SelectedActors = GEditor->GetSelectedActors();
 			SelectedActors->GetSelectedObjects(ActorObjs);
 
-			FString message = "Number of objects selected after duplication: " + FString::FromInt(ActorObjs.Num()) + " " + ActorObjs[0]->GetName();
-			UE_LOG(LogTemp, Warning, TEXT("%s"), *message);
 
 			//setup temp meshes package
 			UPackage* NewPackageName = CreatePackage(TEXT("/Game/TempMesh"));
@@ -486,8 +484,6 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 			//take the static meshes that we set up earlier and use them to create a static mesh
 			UStaticMesh* tmpStatMesh = MeshUtilities.ConvertMeshesToStaticMesh(meshComponentsFromSkel, exportObjects[i]->GetOwner()->GetTransform(), NewPackageName->GetName());
 
-			FString message2 = "created static mesh out of skeletal meshes: " + tmpStatMesh->GetName();
-			UE_LOG(LogTemp, Warning, TEXT("%s"), *message2);
 
 			//create a new static mesh component for the currently selected actor
 			FName NewCompName = TEXT("StaticMeshComponent");
@@ -506,8 +502,6 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 				if (childrenToBeMoved[k]->GetName() != NewCompName.ToString())
 				{
 					childrenToBeMoved[k]->AttachToComponent(NewComp, FAttachmentTransformRules::KeepRelativeTransform);
-					FString message3 = "reattached component: " + childrenToBeMoved[k]->GetName() + " to: " + NewComp->GetName();
-					UE_LOG(LogTemp, Warning, TEXT("%s"), *message3);
 				}
 			}
 			//delete the skeletal mesh component

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.h
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "CoreMinimal.h"
+
 #include "CognitiveVRSettings.h"
 #include "CognitiveEditorData.h"
 #include "IDetailCustomization.h"
@@ -24,6 +26,9 @@
 #include "MaterialUtilities.h"
 #include "MaterialBakingStructures.h"
 #include "IMaterialBakingModule.h"
+#include "MeshUtilities.h"
+#include "UObject/Object.h"
+//#include "Subsystems/EditorActorSubsystem.h"
 //#include "MaterialBakingModule.h"
 #include "MaterialOptions.h"
 #include "DynamicObject.h"
@@ -418,6 +423,9 @@ public:
 
 	//opens blender and run python script. returns process to do stuff after blender has finished
 	FProcHandle ConvertSceneToGLTF();
+
+	IMeshUtilities& MeshUtilities = FModuleManager::Get().LoadModuleChecked<IMeshUtilities>("MeshUtilities");
+
 };
 
 


### PR DESCRIPTION
# Description

Fixed a bug regarding the transform of actors with skeletal meshes when displayed in the scene explorer. The skeletal mesh to be exported now is duplicated and has its skeletal mesh component replaced with a static mesh component created from its original mesh, then that mesh is used in the export data. The temporary static mesh and duplicated actor are cleaned up and deleted after successful export. Also added some package references to the build file.

Height Task ID (If applicable): T-3073

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules