### PR TITLE
refactored skeletal mesh processing

### DIFF
--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.h
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.h
@@ -174,6 +174,12 @@ public:
 	//returns array of strings describing materials being exported - the material type (opaque, translucent, masked) and the paths for each texture
 	//does the actual file writing for saving textures from material to bmps
 	TArray<FString> WizardExportMaterials(FString directory, TArray<FString> ExportedMaterialNames, TArray<UMaterialInterface*> materials);
+
+	void CleanUpDuplicatesAndTempAssets(TArray<AActor*>& ConvertedActorsToDelete, TArray<FAssetData>& TempAssetsToDelete);
+
+	AActor* PrepareSkeletalMeshForExport(AActor* SkeletalMeshActor, TArray<AActor*>& ConvertedActorsToDelete, TArray<FAssetData>& TempAssetsToDelete);
+
+	TArray<AActor*> PrepareSceneForExport(bool OnlyExportSelected, TArray<AActor*>& ConvertedActorsToDelete, TArray<FAssetData>& TempAssetsToDelete);
 	
 	void UploadFromDirectory(FString url, FString directory, FString expectedResponseType);
 


### PR DESCRIPTION
# Description

Refactored and fixed component attach bug in the code processing the skeletal meshes during scene and dynamic object exports, now takes in skeletal mesh actor and references to 2 arrays for duplicated actors and temp assets to delete in a different function after, splitting up that process nicely. ExportScene and ExportDynamicObjectsArray use this to handle skeletal mesh use-cases. This can be used in more places now due to its modularity. Also split up Scene prep done when export button is pressed into its own function as well to clean up the widget code page and place export logic all in CognitiveEditorTools.

Height Task ID (If applicable): T-3926

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules