### PR TITLE
Pawn export/dynamic object export rework

### DIFF
--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.cpp
@@ -605,7 +605,7 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 					//take the skeletal meshes that we set up earlier and use them to create a static mesh
 					UStaticMesh* tmpStatMesh = MeshUtilities.ConvertMeshesToStaticMesh(meshes, exportObjects[i]->GetOwner()->GetTransform(), NewPackageName->GetName());
 					UExporter::ExportToFile(tmpStatMesh, NULL, *tempObject, true);
-					
+					TempAssetsToDelete.Add(tmpStatMesh);
 				}
 			}
 			else
@@ -682,6 +682,9 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 		GLog->Log("FCognitiveEditorTools::ExportDynamicObjectArray Found " + FString::FromInt(ActorsExported) + " meshes for export");
 		FindAllSubDirectoryNames();
 	}
+
+	ObjectTools::DeleteAssets(TempAssetsToDelete, false);
+	TempAssetsToDelete.Empty();
 	return fph;
 }
 

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.cpp
@@ -256,28 +256,28 @@ FProcHandle FCognitiveEditorTools::ExportNewDynamics()
 	//get all dynamic object components in scene. add names/pointers to array
 	for (TActorIterator<AActor> ActorItr(GWorld); ActorItr; ++ActorItr)
 	{
-		UActorComponent* actorComponent = (*ActorItr)->GetComponentByClass(UDynamicObject::StaticClass());
-		if (actorComponent == NULL)
+		for (UActorComponent* actorComponent : ActorItr->GetComponents())
 		{
-			continue;
-		}
-		UDynamicObject* dynamic = Cast<UDynamicObject>(actorComponent);
-		if (dynamic == NULL)
-		{
-			continue;
-		}
-
-		FString path = GetDynamicsExportDirectory() + "/" + dynamic->MeshName + "/" + dynamic->MeshName;
-		FString gltfpath = path + ".gltf";
-		if (FPaths::FileExists(*gltfpath))
-		{
-			//already exported
-			continue;
-		}
-		if (!meshNames.Contains(dynamic->MeshName))
-		{
-			exportObjects.Add(dynamic);
-			meshNames.Add(dynamic->MeshName);
+			if (actorComponent->IsA(UDynamicObject::StaticClass()))
+			{
+				UDynamicObject* dynamicComponent = Cast<UDynamicObject>(actorComponent);
+				if (dynamicComponent == NULL)
+				{
+					continue;
+				}
+				FString path = GetDynamicsExportDirectory() + "/" + dynamicComponent->MeshName + "/" + dynamicComponent->MeshName;
+				FString gltfpath = path + ".gltf";
+				if (FPaths::FileExists(*gltfpath))
+				{
+					//already exported
+					continue;
+				}
+				if (!meshNames.Contains(dynamicComponent->MeshName))
+				{
+					exportObjects.Add(dynamicComponent);
+					meshNames.Add(dynamicComponent->MeshName);
+				}
+			}
 		}
 	}
 
@@ -314,20 +314,21 @@ FProcHandle FCognitiveEditorTools::ExportAllDynamics()
 		// Same as with the Object Iterator, access the subclass instance with the * or -> operators.
 		//AStaticMeshActor *Mesh = *ActorItr;
 
-		UActorComponent* actorComponent = (*ActorItr)->GetComponentByClass(UDynamicObject::StaticClass());
-		if (actorComponent == NULL)
+		for (UActorComponent* actorComponent : ActorItr->GetComponents())
 		{
-			continue;
-		}
-		UDynamicObject* dynamic = Cast<UDynamicObject>(actorComponent);
-		if (dynamic == NULL)
-		{
-			continue;
-		}
-		if (!meshNames.Contains(dynamic->MeshName))
-		{
-			exportObjects.Add(dynamic);
-			meshNames.Add(dynamic->MeshName);
+			if (actorComponent->IsA(UDynamicObject::StaticClass()))
+			{
+				UDynamicObject* dynamicComponent = Cast<UDynamicObject>(actorComponent);
+				if (dynamicComponent == NULL)
+				{
+					continue;
+				}
+				if (!meshNames.Contains(dynamicComponent->MeshName))
+				{
+					exportObjects.Add(dynamicComponent);
+					meshNames.Add(dynamicComponent->MeshName);
+				}
+			}
 		}
 	}
 
@@ -347,22 +348,23 @@ FReply FCognitiveEditorTools::ExportSelectedDynamics()
 	{
 		if (AActor* Actor = Cast<AActor>(*It))
 		{
-			//SelectionSetCache.Add(Actor);
-			UActorComponent* actorComponent = Actor->GetComponentByClass(UDynamicObject::StaticClass());
-			if (actorComponent == NULL)
+			for (UActorComponent* actorComponent : Actor->GetComponents())
 			{
-				continue;
+				if (actorComponent->IsA(UDynamicObject::StaticClass()))
+				{
+					UDynamicObject* dynamicComponent = Cast<UDynamicObject>(actorComponent);
+					if (dynamicComponent == NULL)
+					{
+						continue;
+					}
+					if (!meshNames.Contains(dynamicComponent->MeshName))
+					{
+						SelectionSetCache.Add(dynamicComponent);
+						meshNames.Add(dynamicComponent->MeshName);
+					}
+				}
 			}
-			UDynamicObject* dynamicComponent = Cast<UDynamicObject>(actorComponent);
-			if (dynamicComponent == NULL)
-			{
-				continue;
-			}
-			if (!meshNames.Contains(dynamicComponent->MeshName))
-			{
-				SelectionSetCache.Add(dynamicComponent);
-				meshNames.Add(dynamicComponent->MeshName);
-			}
+
 		}
 	}
 
@@ -381,37 +383,34 @@ FProcHandle FCognitiveEditorTools::ExportDynamicData(TArray< TSharedPtr<FDynamic
 	{
 		if (AActor* Actor = Cast<AActor>(*It))
 		{
-			//SelectionSetCache.Add(Actor);
-			UActorComponent* actorComponent = Actor->GetComponentByClass(UDynamicObject::StaticClass());
-			if (actorComponent == NULL)
+			for (UActorComponent* actorComponent : Actor->GetComponents())
 			{
-				continue;
-			}
-			UDynamicObject* dynamicComponent = Cast<UDynamicObject>(actorComponent);
-			if (dynamicComponent == NULL)
-			{
-				continue;
-			}
-
-			if (meshNames.Contains(dynamicComponent->MeshName))
-			{
-				//mesh will already be exported
-				continue;
-			}
-
-			bool exportActor = false;
-			for (auto& elem : dynamicData)
-			{
-				if (elem->MeshName == dynamicComponent->MeshName)
+				if (actorComponent->IsA(UDynamicObject::StaticClass()))
 				{
-					exportActor = true;
-					break;
+					UDynamicObject* dynamicComponent = Cast<UDynamicObject>(actorComponent);
+					if (dynamicComponent == NULL)
+					{
+						continue;
+					}
+					if (meshNames.Contains(dynamicComponent->MeshName))
+					{
+						continue;
+					}
+					bool exportActor = false;
+					for (auto& elem : dynamicData)
+					{
+						if (elem->MeshName == dynamicComponent->MeshName)
+						{
+							exportActor = true;
+							break;
+						}
+					}
+					if (exportActor)
+					{
+						SelectionSetCache.Add(dynamicComponent);
+						meshNames.Add(dynamicComponent->MeshName);
+					}
 				}
-			}
-			if (exportActor)
-			{
-				SelectionSetCache.Add(dynamicComponent);
-				meshNames.Add(dynamicComponent->MeshName);
 			}
 		}
 	}
@@ -494,30 +493,127 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 		ActorsExported++;
 		GLog->Log("FCognitiveEditorTools::ExportDynamicObjectArray dynamic output directory " + tempObject);
 
-		//check if export object is a pawn
-		//if so, we need to export the associated mesh directly instead of the object in the level
-		if (exportObjects[i]->GetOwner()->IsA(APawn::StaticClass()))
+
+
+		int DynamicObjectCount = 0;
+		//check if this D.O. is on an object with another D.O.
+		for (UActorComponent* Component : exportObjects[i]->GetOwner()->GetComponents())
 		{
-			//get mesh component and cast it to find if its skeletal or static
-			UMeshComponent* pawnMesh = Cast<UMeshComponent>(exportObjects[i]->GetOwner()->GetComponentByClass(UMeshComponent::StaticClass()));
-			USkeletalMeshComponent* skelPawn = Cast<USkeletalMeshComponent>(pawnMesh);
-			UStaticMeshComponent* staticPawn = Cast<UStaticMeshComponent>(pawnMesh);
-			//check if mesh is skeletal
-			if (skelPawn != nullptr)
+			if (Component->IsA(UDynamicObject::StaticClass()))
 			{
-				USkeletalMesh* skelMesh = skelPawn->SkeletalMesh;
-				UExporter::ExportToFile(skelMesh, NULL, *tempObject, true);
-			}
-			else if (staticPawn != nullptr) //check if mesh is static
-			{
-				UStaticMesh* staticMesh = staticPawn->GetStaticMesh();
-				UExporter::ExportToFile(staticMesh, NULL, *tempObject, true);
+				DynamicObjectCount++;
 			}
 		}
-		else //if not a pawn, export the object in the scene normally
+
+		if (DynamicObjectCount > 1) //multiple D.O.s
 		{
-			//exports the currently selected actor(s)
-			GUnrealEd->ExportMap(GWorld, *tempObject, true);
+
+			UE_LOG(LogTemp, Warning, TEXT("FOUND MULTIPLE DYNAMIC OBJECTS"));
+
+			//if so, we check that each D.O. has a mesh parents
+			//we go through and check each D.O. (either make a list then iterate on it or check parent while seeing the D.O.s
+			UMeshComponent* ParentMesh = Cast<UMeshComponent>(exportObjects[i]->GetAttachParent());
+
+			if (ParentMesh)
+			{
+				// Check for Static Mesh Component
+				UStaticMeshComponent* StaticMeshComp = Cast<UStaticMeshComponent>(ParentMesh);
+				if (StaticMeshComp && StaticMeshComp->GetStaticMesh())
+				{
+					UStaticMesh* StaticMeshAsset = StaticMeshComp->GetStaticMesh();
+					// Do something with StaticMeshAsset
+					UExporter::ExportToFile(StaticMeshAsset, NULL, *tempObject, true);
+				}
+
+				// Check for Skeletal Mesh Component
+				USkeletalMeshComponent* SkeletalMeshComp = Cast<USkeletalMeshComponent>(ParentMesh);
+				if (SkeletalMeshComp && SkeletalMeshComp->SkeletalMesh)
+				{
+					USkeletalMesh* SkeletalMeshAsset = SkeletalMeshComp->SkeletalMesh;
+					// Do something with SkeletalMeshAsset
+					UExporter::ExportToFile(SkeletalMeshAsset, NULL, *tempObject, true);
+				}
+
+			}
+			else //incorrect configuration of multiple D.O.s
+			{
+				FSuppressableWarningDialog::FSetupInfo DOExportSettingsInfo(LOCTEXT("DynamicObjectExportSettingsBody", "You are exporting a dynamic object on an actor with multiple dynamic objects, but they are not configured correctly. If you want to track multiple meshes on an actor with multiple dynamic objects, make sure each dynamic object is a child of its respective mesh"), LOCTEXT("DynamicObjectExportSettingsTitle", "Incorrect Dynamic Object Export Configuration"), "ExportSelectedDynamicsObjectsBody");
+				DOExportSettingsInfo.ConfirmText = LOCTEXT("Ok", "Ok");
+				DOExportSettingsInfo.CheckBoxText = FText::FromString("Don't show again");
+				FSuppressableWarningDialog DOExportSelectedDynamicMeshes(DOExportSettingsInfo);
+				DOExportSelectedDynamicMeshes.ShowModal();
+
+				continue;
+			}
+		}
+		else //only 1 D.O. proceed as normal
+		{
+			//if theres only 1 D.O. on the object, continue normally
+
+			//pawn export process needs to be able to group meshes somehow on D.O.s with 1 D.O. and multiple meshes
+			if (exportObjects[i]->GetOwner()->IsA(APawn::StaticClass()))
+			{
+				UE_LOG(LogTemp, Warning, TEXT("FOUND PAWN CLASS, EXPORTING MESH"));
+				UMeshComponent* pawnMesh = Cast<UMeshComponent>(exportObjects[i]->GetOwner()->GetComponentByClass(UMeshComponent::StaticClass()));
+				TArray<UActorComponent*> pawnMeshes;
+				exportObjects[i]->GetOwner()->GetComponents(UMeshComponent::StaticClass(), pawnMeshes);
+
+				TArray< UMeshComponent*> meshes;
+				for (int32 j = 0; j < pawnMeshes.Num(); j++)
+				{
+					UStaticMeshComponent* mesh = Cast<UStaticMeshComponent>(pawnMeshes[j]);
+					if (mesh == NULL)
+					{
+						continue;
+					}
+
+					ULevel* componentLevel = pawnMeshes[j]->GetComponentLevel();
+					if (componentLevel->bIsVisible == 0)
+					{
+						continue;
+						//not visible! possibly on a disabled sublevel
+					}
+
+					meshes.Add(mesh);
+				}
+
+				TArray<UActorComponent*> actorSkeletalComponents;
+				exportObjects[i]->GetOwner()->GetComponents(USkeletalMeshComponent::StaticClass(), actorSkeletalComponents);
+				for (int32 j = 0; j < actorSkeletalComponents.Num(); j++)
+				{
+					USkeletalMeshComponent* mesh = Cast<USkeletalMeshComponent>(actorSkeletalComponents[j]);
+					if (mesh == NULL)
+					{
+						continue;
+					}
+
+					ULevel* componentLevel = actorSkeletalComponents[j]->GetComponentLevel();
+					if (componentLevel->bIsVisible == 0)
+					{
+						continue;
+						//not visible! possibly on a disabled sublevel
+					}
+
+					meshes.Add(mesh);
+				}
+
+				//setup temp meshes package
+				UPackage* NewPackageName = CreatePackage(TEXT("/Game/TempMesh"));
+
+				if (meshes.Num() > 0)
+				{
+					//take the skeletal meshes that we set up earlier and use them to create a static mesh
+					UStaticMesh* tmpStatMesh = MeshUtilities.ConvertMeshesToStaticMesh(meshes, exportObjects[i]->GetOwner()->GetTransform(), NewPackageName->GetName());
+					UExporter::ExportToFile(tmpStatMesh, NULL, *tempObject, true);
+					
+				}
+			}
+			else
+			{
+				//exports the currently selected actor(s)
+				UE_LOG(LogTemp, Warning, TEXT("DOING REGULAR MAP EXPORT"));
+				GUnrealEd->ExportMap(GWorld, *tempObject, true);
+			}
 		}
 
 

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.h
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.h
@@ -164,18 +164,18 @@ public:
 	void UploadFromDirectory(FString url, FString directory, FString expectedResponseType);
 
 	//dynamic objects
-	//Runs the built-in fbx exporter with all meshes
+	//Runs the built-in gltf exporter with all meshes
 	FProcHandle ExportAllDynamics();
-	//Runs the built-in fbx exporter with all meshes that don't have an exported .gltf
+	//Runs the built-in gltf exporter with all meshes that don't have an exported .gltf
 		FProcHandle ExportNewDynamics();
 
-	//Runs the built-in fbx exporter with selected meshes
+	//Runs the built-in gltf exporter with selected meshes
 		FReply ExportSelectedDynamics();
 		FProcHandle ExportDynamicData(TArray< TSharedPtr<FDynamicData>> dynamicData);
 	
 
 	//this is the important function for exporting dynamics. all other other dynamic export functions lead to this
-		//sets position to origin, export as fbx, generate screenshot, bake materials to textures (not necessary)
+		//sets position to origin, export as gltf, generate screenshot
 	FProcHandle ExportDynamicObjectArray(TArray<UDynamicObject*> exportObjects);
 
 

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.h
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.h
@@ -178,6 +178,7 @@ public:
 		//sets position to origin, export as gltf, generate screenshot
 	FProcHandle ExportDynamicObjectArray(TArray<UDynamicObject*> exportObjects);
 
+	TArray<FAssetData> TempAssetsToDelete;
 
 	//uploads each dynamic object using its directory to the current scene
 	UFUNCTION(Exec, Category = "Dynamics")


### PR DESCRIPTION
# Description

Reworking dynamic object export using gltf Exporter to export pawns and actors/pawns with multiple dynamic objects means to track multiple meshes on one actor/pawn. To do the latter, dynamic objects need to be a child of the mesh they want to represent. Mind the mesh names of course.

Height Task ID (If applicable): T-4456, T-2145

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules