### PR TITLE
SDK Version 0.27.3 Hotfix

### DIFF
--- a/CognitiveVRTest/Plugins/CognitiveVR/CognitiveVR.uplugin
+++ b/CognitiveVRTest/Plugins/CognitiveVR/CognitiveVR.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "0.27.2",
+	"VersionName": "0.27.3",
 	"FriendlyName": "Cognitive3D Analytics",
 	"Description": "Cognitive3D Analytics for Unreal",
 	"Category": "Analytics",

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/CognitiveVR.Build.cs
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/CognitiveVR.Build.cs
@@ -51,7 +51,7 @@ namespace UnrealBuildTool.Rules
                     "JsonUtilities",
 					"UMG",
 					"EngineSettings",
-					"EyeTracker",
+					"EyeTracker"
 				}
 				);
 

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/CognitiveVR.Build.cs
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/CognitiveVR.Build.cs
@@ -51,6 +51,7 @@ namespace UnrealBuildTool.Rules
                     "JsonUtilities",
 					"UMG",
 					"EngineSettings",
+					"EyeTracker",
 				}
 				);
 
@@ -59,9 +60,6 @@ namespace UnrealBuildTool.Rules
 		
 			//uncomment these lines to enable Oculus/Meta platform functionality. Uses OculusVR for UE4 and OculusXR (MetaXR) for UE5.
 			//PublicDefinitions.Add("INCLUDE_OCULUS_PLUGIN");
-			//PublicDependencyModuleNames.AddRange(new string[] { "OnlineSubsystem", "OnlineSubsystemOculus", "OculusHMD" });
-			
-			
 			//PublicDependencyModuleNames.AddRange(new string[] {"OculusHMD" });
 			//uncomment this to enable eye tracking support using IEyeTracker interface (varjo openxr support, etc)
 			//PublicDefinitions.Add("OPENXR_EYETRACKING");

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/CognitiveVR.Build.cs
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/CognitiveVR.Build.cs
@@ -51,7 +51,6 @@ namespace UnrealBuildTool.Rules
                     "JsonUtilities",
 					"UMG",
 					"EngineSettings",
-					"EyeTracker"
 				}
 				);
 
@@ -63,6 +62,7 @@ namespace UnrealBuildTool.Rules
 			//PublicDependencyModuleNames.AddRange(new string[] { "OnlineSubsystem", "OnlineSubsystemOculus", "OculusHMD" });
 			
 			
+			//PublicDependencyModuleNames.AddRange(new string[] {"OculusHMD" });
 			//uncomment this to enable eye tracking support using IEyeTracker interface (varjo openxr support, etc)
 			//PublicDefinitions.Add("OPENXR_EYETRACKING");
 

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Public/CognitiveVR.h
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Public/CognitiveVR.h
@@ -13,7 +13,7 @@
 DEFINE_LOG_CATEGORY_STATIC(CognitiveVR_Log, Log, All);
 
 #define COGNITIVEVR_SDK_NAME "unreal"
-#define COGNITIVEVR_SDK_VERSION "0.27.2"
+#define COGNITIVEVR_SDK_VERSION "0.27.3"
 
 class IAnalyticsProvider;
 class FAnalyticsProviderCognitiveVR;

--- a/update5_0.py
+++ b/update5_0.py
@@ -125,7 +125,7 @@ print (version)
 replaceline(cwd+"/Plugins\CognitiveVR\Source\CognitiveVR\CognitiveVR.Build.cs","			|| Target.Platform == UnrealTargetPlatform.Win32","//			|| Target.Platform == UnrealTargetPlatform.Win32")
 
 #change definitions and oculus plugin include in build.cs
-replaceline(cwd+"/Plugins\CognitiveVR\Source\CognitiveVR\CognitiveVR.Build.cs","			//PublicDependencyModuleNames.AddRange(new string[] { \"OnlineSubsystem\", \"OnlineSubsystemOculus\", \"OculusHMD\" });","			//PublicDependencyModuleNames.AddRange(new string[] { \"OnlineSubsystem\", \"OnlineSubsystemOculus\", \"OculusXRHMD\" });")
+replaceline(cwd+"/Plugins\CognitiveVR\Source\CognitiveVR\CognitiveVR.Build.cs","			//PublicDependencyModuleNames.AddRange(new string[] { \"OculusHMD\" });","			//PublicDependencyModuleNames.AddRange(new string[] { \"OculusXRHMD\" });")
 
 # save to zip archive
 output_filename = cwd+"/C3D_Plugin"+version+"_ue"+engineversion+"_"+enginesubversion

--- a/update5_1.py
+++ b/update5_1.py
@@ -126,7 +126,7 @@ print (version)
 replaceline(cwd+"/Plugins\CognitiveVR\Source\CognitiveVR\CognitiveVR.Build.cs","			|| Target.Platform == UnrealTargetPlatform.Win32","//			|| Target.Platform == UnrealTargetPlatform.Win32")
 
 #change definitions and oculus plugin include in build.cs
-replaceline(cwd+"/Plugins\CognitiveVR\Source\CognitiveVR\CognitiveVR.Build.cs","			//PublicDependencyModuleNames.AddRange(new string[] { \"OnlineSubsystem\", \"OnlineSubsystemOculus\", \"OculusHMD\" });","			//PublicDependencyModuleNames.AddRange(new string[] { \"OnlineSubsystem\", \"OnlineSubsystemOculus\", \"OculusXRHMD\" });")
+replaceline(cwd+"/Plugins\CognitiveVR\Source\CognitiveVR\CognitiveVR.Build.cs","			//PublicDependencyModuleNames.AddRange(new string[] { \"OculusHMD\" });","			//PublicDependencyModuleNames.AddRange(new string[] { \"OculusXRHMD\" });")
 
 
 # save to zip archive

--- a/update5_2.py
+++ b/update5_2.py
@@ -126,7 +126,7 @@ print (version)
 replaceline(cwd+"/Plugins\CognitiveVR\Source\CognitiveVR\CognitiveVR.Build.cs","			|| Target.Platform == UnrealTargetPlatform.Win32","//			|| Target.Platform == UnrealTargetPlatform.Win32")
 
 #change definitions and oculus plugin include in build.cs
-replaceline(cwd+"/Plugins\CognitiveVR\Source\CognitiveVR\CognitiveVR.Build.cs","			//PublicDependencyModuleNames.AddRange(new string[] { \"OnlineSubsystem\", \"OnlineSubsystemOculus\", \"OculusHMD\" });","			//PublicDependencyModuleNames.AddRange(new string[] { \"OnlineSubsystem\", \"OnlineSubsystemOculus\", \"OculusXRHMD\" });")
+replaceline(cwd+"/Plugins\CognitiveVR\Source\CognitiveVR\CognitiveVR.Build.cs","			//PublicDependencyModuleNames.AddRange(new string[] { \"OculusHMD\" });","			//PublicDependencyModuleNames.AddRange(new string[] { \"OculusXRHMD\" });")
 
 
 # save to zip archive

--- a/update5_3.py
+++ b/update5_3.py
@@ -126,7 +126,7 @@ print (version)
 replaceline(cwd+"/Plugins\CognitiveVR\Source\CognitiveVR\CognitiveVR.Build.cs","			|| Target.Platform == UnrealTargetPlatform.Win32","//			|| Target.Platform == UnrealTargetPlatform.Win32")
 
 #change definitions and oculus plugin include in build.cs
-replaceline(cwd+"/Plugins\CognitiveVR\Source\CognitiveVR\CognitiveVR.Build.cs","			//PublicDependencyModuleNames.AddRange(new string[] { \"OnlineSubsystem\", \"OnlineSubsystemOculus\", \"OculusHMD\" });","			//PublicDependencyModuleNames.AddRange(new string[] { \"OnlineSubsystem\", \"OnlineSubsystemOculus\", \"OculusXRHMD\" });")
+replaceline(cwd+"/Plugins\CognitiveVR\Source\CognitiveVR\CognitiveVR.Build.cs","			//PublicDependencyModuleNames.AddRange(new string[] { \"OculusHMD\" });","			//PublicDependencyModuleNames.AddRange(new string[] { \"OculusXRHMD\" });")
 
 insertline(cwd+"/Plugins\CognitiveVR\Source\CognitiveVR\CognitiveVR.Build.cs","					\"Slate\",","					\"XRBase\",",)
 


### PR DESCRIPTION
# Description

A hotfix removing references to OnlineSubsystem and OnlineSubsystemOculus from the build.cs file line that is meant to be uncommented for OculusHMD features, such as boundary features. This is done because a developer who only has OculusVR/MetaXR plugin installed might not have OnlineSubsystemOculus installed, which causes build errors that are terribly misleading. Also updated relevant python scripts for generating UE5 versions of the plugin.

Height Task ID (If applicable): T-4815

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules