### PR TITLE
Id pool changes

### DIFF
--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/CognitiveVREditor.Build.cs
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/CognitiveVREditor.Build.cs
@@ -31,7 +31,9 @@ public class CognitiveVREditor : ModuleRules
                 "AssetTools",
                 "SceneOutliner",
                 "EditorScriptingUtilities",
-                "MeshUtilities"
+                "MeshUtilities",
+                "GLTFExporter",
+                "AssetRegistry"
             });
 
         PrivateDependencyModuleNames.AddRange(

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.cpp
@@ -1925,6 +1925,7 @@ FReply FCognitiveEditorTools::RefreshDisplayDynamicObjectsCountInScene()
 		{
 			FString idMessage = TEXT("Id generated during runtime");
 			SceneDynamics.Add(MakeShareable(new FDynamicData(dynamic->GetOwner()->GetName(), dynamic->MeshName, *idMessage)));
+			SceneDynamics.Add(MakeShareable(new FDynamicData(dynamic->GetOwner()->GetName(), dynamic->MeshName, idMessage)));
 		}
 		//dynamics.Add(dynamic);
 	}

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.cpp
@@ -1916,7 +1916,16 @@ FReply FCognitiveEditorTools::RefreshDisplayDynamicObjectsCountInScene()
 		{
 			continue;
 		}
-		SceneDynamics.Add(MakeShareable(new FDynamicData(dynamic->GetOwner()->GetName(), dynamic->MeshName, dynamic->CustomId)));
+		//populate id based on id type
+		if (dynamic->IdSourceType == EIdSourceType::CustomId)
+		{
+			SceneDynamics.Add(MakeShareable(new FDynamicData(dynamic->GetOwner()->GetName(), dynamic->MeshName, dynamic->CustomId)));
+		}
+		else if (dynamic->IdSourceType == EIdSourceType::GeneratedId)
+		{
+			FString idMessage = TEXT("Id generated during runtime");
+			SceneDynamics.Add(MakeShareable(new FDynamicData(dynamic->GetOwner()->GetName(), dynamic->MeshName, *idMessage)));
+		}
 		//dynamics.Add(dynamic);
 	}
 
@@ -1928,6 +1937,35 @@ FReply FCognitiveEditorTools::RefreshDisplayDynamicObjectsCountInScene()
 	{
 		DuplicateDyanmicObjectVisibility = EVisibility::Collapsed;
 	}
+
+	FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+	IAssetRegistry& AssetRegistry = AssetRegistryModule.Get();
+
+	FARFilter Filter;
+	Filter.ClassNames.Add(UDynamicIdPoolAsset::StaticClass()->GetFName());
+	Filter.bRecursiveClasses = true; // Set to true if you want to include subclasses
+
+	TArray<FAssetData> AssetData;
+	AssetRegistry.GetAssets(Filter, AssetData);
+
+	for (const FAssetData& Asset : AssetData)
+	{
+		// Do something with each asset, e.g., log its name
+		UE_LOG(LogTemp, Log, TEXT("Found Asset: %s"), *Asset.AssetName.ToString());
+
+		//get the actual asset from the asset data
+		UObject* IdPoolObject = Asset.GetAsset();
+		//cast it to a dynamic id pool asset
+		UDynamicIdPoolAsset* IdPoolAsset = Cast<UDynamicIdPoolAsset>(IdPoolObject);
+
+		//construct a string for the number of ids in the pool
+		FString IdString = FString::Printf(TEXT("ID Pool(%d)"), IdPoolAsset->Ids.Num());
+
+		//add it as TSharedPtr<FDynamicData> to the SceneDynamics
+		SceneDynamics.Add(MakeShareable(new FDynamicData(IdPoolAsset->PrefabName, IdPoolAsset->MeshName, IdString)));
+	}
+
+
 
 	return FReply::Handled();
 }

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.h
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.h
@@ -23,6 +23,7 @@
 #include "MainFrame.h"
 #include "IPluginManager.h"
 #include "AssetRegistryModule.h"
+#include "IAssetRegistry.h"
 #include "MaterialUtilities.h"
 #include "MaterialBakingStructures.h"
 #include "IMaterialBakingModule.h"
@@ -402,10 +403,7 @@ public:
 
 	//exporting scene.
 	//create directory
-	//export scene as obj
-	//export materials
-	//build materiallist.txt
-	//run python script
+	//export scene as gltf
 	void ExportScene(TArray<AActor*> actorsToExport);
 
 	void ValidateGeneratedFiles();

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/DynamicObjectManagerWidget.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/DynamicObjectManagerWidget.cpp
@@ -359,6 +359,43 @@ EVisibility SDynamicObjectManagerWidget::GetDuplicateDyanmicObjectVisibility() c
 
 FReply SDynamicObjectManagerWidget::UploadAllDynamicObjects()
 {
+	FSuppressableWarningDialog::FSetupInfo Info1(LOCTEXT("UploadIdsForAggregation", "Do you want to Upload all Dynamic Object Id Pool's Ids for Aggregation?"), LOCTEXT("UploadIdsForAggregationTitle", "Upload Ids For Aggregation"), "UploadIdsForAggregationBody");
+	Info1.ConfirmText = LOCTEXT("Yes", "Yes");
+	Info1.CancelText = LOCTEXT("No", "No");
+	Info1.CheckBoxText = FText();
+	FSuppressableWarningDialog UploadSelectedIdPools(Info1);
+	FSuppressableWarningDialog::EResult result1 = UploadSelectedIdPools.ShowModal();
+
+	if (result1 == FSuppressableWarningDialog::EResult::Confirm)
+	{
+		//find the corresponding asset
+		FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+		IAssetRegistry& AssetRegistry = AssetRegistryModule.Get();
+
+		FARFilter Filter;
+		Filter.ClassNames.Add(UDynamicIdPoolAsset::StaticClass()->GetFName());
+		Filter.bRecursiveClasses = true; // Set to true if you want to include subclasses
+
+		TArray<FAssetData> AssetData;
+		AssetRegistry.GetAssets(Filter, AssetData);
+
+		for (const FAssetData& Asset : AssetData)
+		{
+			//get the actual asset from the asset data
+			UObject* IdPoolObject = Asset.GetAsset();
+			//cast it to a dynamic id pool asset
+			UDynamicIdPoolAsset* IdPoolAsset = Cast<UDynamicIdPoolAsset>(IdPoolObject);
+
+			UE_LOG(LogTemp, Warning, TEXT("Found dynamic id pool asset %s, uploading ids"), *IdPoolAsset->PrefabName);
+			FReply uploadReply = FCognitiveEditorTools::GetInstance()->UploadDynamicsManifestIds(IdPoolAsset->Ids, IdPoolAsset->MeshName, IdPoolAsset->PrefabName);
+			if (uploadReply.IsEventHandled())
+			{
+
+			}
+
+		}
+	}
+
 	//popup asking if meshes should be exported too
 	FSuppressableWarningDialog::FSetupInfo Info(LOCTEXT("ExportSelectedDynamicsBody", "Do you want to export all Dynamic Object meshes before uploading to Scene Explorer?"), LOCTEXT("ExportSelectedDynamicsTitle", "Export Selected Dynamic Objects"), "ExportSelectedDynamicsBody");
 	Info.ConfirmText = LOCTEXT("Yes", "Yes");

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/DynamicObjectManagerWidget.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/DynamicObjectManagerWidget.cpp
@@ -415,7 +415,7 @@ FReply SDynamicObjectManagerWidget::UploadAllDynamicObjects()
 		FProcHandle fph = FCognitiveEditorTools::GetInstance()->ExportAllDynamics();
 	}
 
-	FSuppressableWarningDialog::FSetupInfo Info2(LOCTEXT("UploadSelectedDynamicsBody", "Do you want to upload all Dynamic Object to Scene Explorer?"), LOCTEXT("UploadSelectedDynamicsTitle", "Upload Selected Dynamic Objects"), "UploadSelectedDynamicsBody");
+	FSuppressableWarningDialog::FSetupInfo Info2(LOCTEXT("UploadSelectedDynamicsBody", "Do you want to upload all Dynamic Object to Scene Explorer? Note: This will only upload meshes that have been exported."), LOCTEXT("UploadSelectedDynamicsTitle", "Upload Selected Dynamic Objects"), "UploadSelectedDynamicsBody");
 	Info2.ConfirmText = LOCTEXT("Yes", "Yes");
 	Info2.CancelText = LOCTEXT("No", "No");
 	Info2.CheckBoxText = FText();
@@ -524,7 +524,7 @@ FReply SDynamicObjectManagerWidget::UploadSelectedDynamicObjects()
 	}
 
 	//then perform upload
-	FSuppressableWarningDialog::FSetupInfo Info2(LOCTEXT("UploadSelectedDynamicsBody", "Do you want to upload the selected Dynamic Object to Scene Explorer?"), LOCTEXT("UploadSelectedDynamicsTitle", "Upload Selected Dynamic Objects"), "UploadSelectedDynamicsBody");
+	FSuppressableWarningDialog::FSetupInfo Info2(LOCTEXT("UploadSelectedDynamicsBody", "Do you want to upload the selected Dynamics to Scene Explorer? Note: This will only upload meshes that have been exported."), LOCTEXT("UploadSelectedDynamicsTitle", "Upload Selected Dynamic Objects"), "UploadSelectedDynamicsBody");
 	Info2.ConfirmText = LOCTEXT("Yes", "Yes");
 	Info2.CancelText = LOCTEXT("No", "No");
 	Info2.CheckBoxText = FText();

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/DynamicObjectManagerWidget.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/DynamicObjectManagerWidget.cpp
@@ -359,42 +359,48 @@ EVisibility SDynamicObjectManagerWidget::GetDuplicateDyanmicObjectVisibility() c
 
 FReply SDynamicObjectManagerWidget::UploadAllDynamicObjects()
 {
-	FSuppressableWarningDialog::FSetupInfo Info1(LOCTEXT("UploadIdsForAggregation", "Do you want to Upload all Dynamic Object Id Pool's Ids for Aggregation?"), LOCTEXT("UploadIdsForAggregationTitle", "Upload Ids For Aggregation"), "UploadIdsForAggregationBody");
-	Info1.ConfirmText = LOCTEXT("Yes", "Yes");
-	Info1.CancelText = LOCTEXT("No", "No");
-	Info1.CheckBoxText = FText();
-	FSuppressableWarningDialog UploadSelectedIdPools(Info1);
-	FSuppressableWarningDialog::EResult result1 = UploadSelectedIdPools.ShowModal();
+	//find the corresponding asset
+	FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+	IAssetRegistry& AssetRegistry = AssetRegistryModule.Get();
 
-	if (result1 == FSuppressableWarningDialog::EResult::Confirm)
+	FARFilter Filter;
+	Filter.ClassNames.Add(UDynamicIdPoolAsset::StaticClass()->GetFName());
+	Filter.bRecursiveClasses = true; // Set to true if you want to include subclasses
+
+	TArray<FAssetData> AssetData;
+	AssetRegistry.GetAssets(Filter, AssetData);
+
+	if (AssetData.Num() > 0)
 	{
-		//find the corresponding asset
-		FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
-		IAssetRegistry& AssetRegistry = AssetRegistryModule.Get();
+		FSuppressableWarningDialog::FSetupInfo Info1(LOCTEXT("UploadIdsForAggregation", "Do you want to Upload all Dynamic Object Id Pool's Ids for Aggregation?"), LOCTEXT("UploadIdsForAggregationTitle", "Upload Ids For Aggregation"), "UploadIdsForAggregationBody");
+		Info1.ConfirmText = LOCTEXT("Yes", "Yes");
+		Info1.CancelText = LOCTEXT("No", "No");
+		Info1.CheckBoxText = FText();
+		FSuppressableWarningDialog UploadSelectedIdPools(Info1);
+		FSuppressableWarningDialog::EResult result1 = UploadSelectedIdPools.ShowModal();
 
-		FARFilter Filter;
-		Filter.ClassNames.Add(UDynamicIdPoolAsset::StaticClass()->GetFName());
-		Filter.bRecursiveClasses = true; // Set to true if you want to include subclasses
-
-		TArray<FAssetData> AssetData;
-		AssetRegistry.GetAssets(Filter, AssetData);
-
-		for (const FAssetData& Asset : AssetData)
+		if (result1 == FSuppressableWarningDialog::EResult::Confirm)
 		{
-			//get the actual asset from the asset data
-			UObject* IdPoolObject = Asset.GetAsset();
-			//cast it to a dynamic id pool asset
-			UDynamicIdPoolAsset* IdPoolAsset = Cast<UDynamicIdPoolAsset>(IdPoolObject);
-
-			UE_LOG(LogTemp, Warning, TEXT("Found dynamic id pool asset %s, uploading ids"), *IdPoolAsset->PrefabName);
-			FReply uploadReply = FCognitiveEditorTools::GetInstance()->UploadDynamicsManifestIds(IdPoolAsset->Ids, IdPoolAsset->MeshName, IdPoolAsset->PrefabName);
-			if (uploadReply.IsEventHandled())
+			for (const FAssetData& Asset : AssetData)
 			{
+				//get the actual asset from the asset data
+				UObject* IdPoolObject = Asset.GetAsset();
+				//cast it to a dynamic id pool asset
+				UDynamicIdPoolAsset* IdPoolAsset = Cast<UDynamicIdPoolAsset>(IdPoolObject);
+
+				UE_LOG(LogTemp, Warning, TEXT("Found dynamic id pool asset %s, uploading ids"), *IdPoolAsset->PrefabName);
+				FReply uploadReply = FCognitiveEditorTools::GetInstance()->UploadDynamicsManifestIds(IdPoolAsset->Ids, IdPoolAsset->MeshName, IdPoolAsset->PrefabName);
+				if (uploadReply.IsEventHandled())
+				{
+
+				}
 
 			}
-
 		}
 	}
+
+		
+	
 
 	//popup asking if meshes should be exported too
 	FSuppressableWarningDialog::FSetupInfo Info(LOCTEXT("ExportSelectedDynamicsBody", "Do you want to export all Dynamic Object meshes before uploading to Scene Explorer?"), LOCTEXT("ExportSelectedDynamicsTitle", "Export Selected Dynamic Objects"), "ExportSelectedDynamicsBody");

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/DynamicObjectManagerWidget.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/DynamicObjectManagerWidget.cpp
@@ -289,7 +289,7 @@ void SDynamicObjectManagerWidget::Construct(const FArguments& Args)
 					[
 						SNew(SButton)
 						.IsEnabled(this, &SDynamicObjectManagerWidget::IsUploadAllEnabled)
-						.Text(FText::FromString("Upload All Meshes"))
+						.Text(FText::FromString("Upload All Dynamics"))
 						.ToolTipText(this, &SDynamicObjectManagerWidget::UploadAllMeshesTooltip)
 						.OnClicked_Raw(this, &SDynamicObjectManagerWidget::UploadAllDynamicObjects)
 					]
@@ -408,23 +408,79 @@ FReply SDynamicObjectManagerWidget::UploadSelectedDynamicObjects()
 {
 	auto selected = SceneDynamicObjectTable->TableViewWidget->GetSelectedItems();
 
-	//popup asking if meshes should be exported too
-	FSuppressableWarningDialog::FSetupInfo Info(LOCTEXT("ExportSelectedDynamicsBody", "Do you want to export the selected Dynamic Object meshes before uploading to Scene Explorer?"), LOCTEXT("ExportSelectedDynamicsTitle", "Export Selected Dynamic Objects"), "ExportSelectedDynamicsBody");
-	Info.ConfirmText = LOCTEXT("Yes", "Yes");
-	Info.CancelText = LOCTEXT("No", "No");
-	Info.CheckBoxText = FText();
-	FSuppressableWarningDialog ExportSelectedDynamicMeshes(Info);
-	FSuppressableWarningDialog::EResult result = ExportSelectedDynamicMeshes.ShowModal();
 
-	if (result == FSuppressableWarningDialog::EResult::Confirm)
+	for (auto& dynamic : selected)
 	{
-		FProcHandle fph = FCognitiveEditorTools::GetInstance()->ExportDynamicData(selected);
-		if (fph.IsValid())
+		//found a selected ID Pool item
+		if (dynamic->Id.Contains("ID Pool"))
 		{
-			FPlatformProcess::WaitForProc(fph);
-		}
-	}	
+			FSuppressableWarningDialog::FSetupInfo Info1(LOCTEXT("UploadIdsForAggregation", "Do you want to Upload the selected Dynamic Object Id Pool's Ids for Aggregation?"), LOCTEXT("UploadIdsForAggregationTitle", "Upload Ids For Aggregation"), "UploadIdsForAggregationBody");
+			Info1.ConfirmText = LOCTEXT("Yes", "Yes");
+			Info1.CancelText = LOCTEXT("No", "No");
+			Info1.CheckBoxText = FText();
+			FSuppressableWarningDialog UploadSelectedIdPools(Info1);
+			FSuppressableWarningDialog::EResult result1 = UploadSelectedIdPools.ShowModal();
 
+			if (result1 == FSuppressableWarningDialog::EResult::Confirm)
+			{
+				//find the corresponding asset
+				FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+				IAssetRegistry& AssetRegistry = AssetRegistryModule.Get();
+
+				FARFilter Filter;
+				Filter.ClassNames.Add(UDynamicIdPoolAsset::StaticClass()->GetFName());
+				Filter.bRecursiveClasses = true; // Set to true if you want to include subclasses
+
+				TArray<FAssetData> AssetData;
+				AssetRegistry.GetAssets(Filter, AssetData);
+
+				for (const FAssetData& Asset : AssetData)
+				{
+					//get the actual asset from the asset data
+					UObject* IdPoolObject = Asset.GetAsset();
+					//cast it to a dynamic id pool asset
+					UDynamicIdPoolAsset* IdPoolAsset = Cast<UDynamicIdPoolAsset>(IdPoolObject);
+
+					if (IdPoolAsset->PrefabName == dynamic->Name && IdPoolAsset->MeshName == dynamic->MeshName)
+					{
+						UE_LOG(LogTemp, Warning, TEXT("Found dynamic id pool asset %s, uploading ids"), *IdPoolAsset->PrefabName);
+						FReply uploadReply = FCognitiveEditorTools::GetInstance()->UploadDynamicsManifestIds(IdPoolAsset->Ids, IdPoolAsset->MeshName, IdPoolAsset->PrefabName);
+						if (uploadReply.IsEventHandled())
+						{
+
+						}
+
+					}
+				}
+			}
+			
+		}//end of if dynamic is id pool
+		else //otherwise handle export for meshes
+		{
+
+			//popup asking if meshes should be exported too
+			FSuppressableWarningDialog::FSetupInfo Info(LOCTEXT("ExportSelectedDynamicsBody", "Do you want to export the selected Dynamic Object meshes before uploading to Scene Explorer?"), LOCTEXT("ExportSelectedDynamicsTitle", "Export Selected Dynamic Objects"), "ExportSelectedDynamicsBody");
+			Info.ConfirmText = LOCTEXT("Yes", "Yes");
+			Info.CancelText = LOCTEXT("No", "No");
+			Info.CheckBoxText = FText();
+			FSuppressableWarningDialog ExportSelectedDynamicMeshes(Info);
+			FSuppressableWarningDialog::EResult result = ExportSelectedDynamicMeshes.ShowModal();
+			TArray<TSharedPtr<FDynamicData>> meshOnly;
+			meshOnly.Add(dynamic);
+			if (result == FSuppressableWarningDialog::EResult::Confirm)
+			{
+				FProcHandle fph = FCognitiveEditorTools::GetInstance()->ExportDynamicData(meshOnly);
+				if (fph.IsValid())
+				{
+					FPlatformProcess::WaitForProc(fph);
+				}
+			}
+
+		}
+		
+	}
+
+	//then perform upload
 	FSuppressableWarningDialog::FSetupInfo Info2(LOCTEXT("UploadSelectedDynamicsBody", "Do you want to upload the selected Dynamic Object to Scene Explorer?"), LOCTEXT("UploadSelectedDynamicsTitle", "Upload Selected Dynamic Objects"), "UploadSelectedDynamicsBody");
 	Info2.ConfirmText = LOCTEXT("Yes", "Yes");
 	Info2.CancelText = LOCTEXT("No", "No");
@@ -547,7 +603,8 @@ FText SDynamicObjectManagerWidget::UploadSelectedText() const
 	//get selected dynamic data
 	//for each unique mesh name
 
-	return FText::FromString("Upload " + FString::FromInt(dynamicMeshNames.Num()) + " Selected Meshes");
+	//return FText::FromString("Upload " + FString::FromInt(dynamicMeshNames.Num()) + " Selected Dynamics");
+	return FText::FromString("Upload " + FString::FromInt(selected.Num()) + " Selected Dynamics");
 }
 
 //if the scene has not been exported, the window displays the onboarding text instead of this scene text

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/DynamicObjectManagerWidget.h
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/DynamicObjectManagerWidget.h
@@ -13,6 +13,8 @@
 #include "STextComboBox.h"
 #include "SListView.h"
 #include "SThrobber.h"
+#include "AssetRegistryModule.h"
+#include "IAssetRegistry.h"
 #include "Runtime/SlateCore/Public/Layout/Visibility.h"
 #include "IImageWrapper.h"
 #include "IImageWrapperModule.h"


### PR DESCRIPTION
# Description

Added ability to see Dynamic Id Pool Assets in the Dynamic Object Manager C3D Window. This allows developers to select the id pools, or have them included with "upload all dynamics", and upload their respective id pools from the convenience of that window, without having to go to each asset and do it from there.

Height Task ID (If applicable): T-4502

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules