### PR TITLE
0.28.1 Hotfix

### DIFF
--- a/CognitiveVRTest/Plugins/CognitiveVR/CognitiveVR.uplugin
+++ b/CognitiveVRTest/Plugins/CognitiveVR/CognitiveVR.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "0.28.0",
+	"VersionName": "0.28.1",
 	"FriendlyName": "Cognitive3D Analytics",
 	"Description": "Cognitive3D Analytics for Unreal",
 	"Category": "Analytics",

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/CognitiveVR.Build.cs
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/CognitiveVR.Build.cs
@@ -60,7 +60,7 @@ namespace UnrealBuildTool.Rules
 		
 			//uncomment these lines to enable Oculus/Meta platform functionality. Uses OculusVR for UE4 and OculusXR (MetaXR) for UE5.
 			//PublicDefinitions.Add("INCLUDE_OCULUS_PLUGIN");
-			//PublicDependencyModuleNames.AddRange(new string[] {"OculusHMD" });
+			//PublicDependencyModuleNames.AddRange(new string[] { "OculusHMD" });
 			//uncomment this to enable eye tracking support using IEyeTracker interface (varjo openxr support, etc)
 			//PublicDefinitions.Add("OPENXR_EYETRACKING");
 

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Public/CognitiveVR.h
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVR/Public/CognitiveVR.h
@@ -13,7 +13,7 @@
 DEFINE_LOG_CATEGORY_STATIC(CognitiveVR_Log, Log, All);
 
 #define COGNITIVEVR_SDK_NAME "unreal"
-#define COGNITIVEVR_SDK_VERSION "0.28.0"
+#define COGNITIVEVR_SDK_VERSION "0.28.1"
 
 class IAnalyticsProvider;
 class FAnalyticsProviderCognitiveVR;

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/CognitiveEditorTools.cpp
@@ -1943,7 +1943,15 @@ FReply FCognitiveEditorTools::RefreshDisplayDynamicObjectsCountInScene()
 	IAssetRegistry& AssetRegistry = AssetRegistryModule.Get();
 
 	FARFilter Filter;
+
+#if ENGINE_MAJOR_VERSION == 4
 	Filter.ClassNames.Add(UDynamicIdPoolAsset::StaticClass()->GetFName());
+#elif ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 0 || ENGINE_MINOR_VERSION == 1)
+	Filter.ClassNames.Add(UDynamicIdPoolAsset::StaticClass()->GetFName());
+#elif ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+	Filter.ClassPaths.Add(UDynamicIdPoolAsset::StaticClass()->GetClassPathName());
+#endif
+
 	Filter.bRecursiveClasses = true; // Set to true if you want to include subclasses
 
 	TArray<FAssetData> AssetData;

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/DynamicObjectManagerWidget.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/DynamicObjectManagerWidget.cpp
@@ -364,7 +364,15 @@ FReply SDynamicObjectManagerWidget::UploadAllDynamicObjects()
 	IAssetRegistry& AssetRegistry = AssetRegistryModule.Get();
 
 	FARFilter Filter;
+
+#if ENGINE_MAJOR_VERSION == 4
 	Filter.ClassNames.Add(UDynamicIdPoolAsset::StaticClass()->GetFName());
+#elif ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 0 || ENGINE_MINOR_VERSION == 1)
+	Filter.ClassNames.Add(UDynamicIdPoolAsset::StaticClass()->GetFName());
+#elif ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+	Filter.ClassPaths.Add(UDynamicIdPoolAsset::StaticClass()->GetClassPathName());
+#endif
+
 	Filter.bRecursiveClasses = true; // Set to true if you want to include subclasses
 
 	TArray<FAssetData> AssetData;
@@ -471,7 +479,13 @@ FReply SDynamicObjectManagerWidget::UploadSelectedDynamicObjects()
 				IAssetRegistry& AssetRegistry = AssetRegistryModule.Get();
 
 				FARFilter Filter;
+#if ENGINE_MAJOR_VERSION == 4
 				Filter.ClassNames.Add(UDynamicIdPoolAsset::StaticClass()->GetFName());
+#elif ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 0 || ENGINE_MINOR_VERSION == 1)
+				Filter.ClassNames.Add(UDynamicIdPoolAsset::StaticClass()->GetFName());
+#elif ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+				Filter.ClassPaths.Add(UDynamicIdPoolAsset::StaticClass()->GetClassPathName());
+#endif
 				Filter.bRecursiveClasses = true; // Set to true if you want to include subclasses
 
 				TArray<FAssetData> AssetData;

--- a/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/SDynamicObjectTableWidget.cpp
+++ b/CognitiveVRTest/Plugins/CognitiveVR/Source/CognitiveVREditor/Private/SDynamicObjectTableWidget.cpp
@@ -87,7 +87,13 @@ TSharedRef<ITableRow> SDynamicObjectTableWidget::OnGenerateRowForTable(TSharedPt
 		IAssetRegistry& AssetRegistry = AssetRegistryModule.Get();
 
 		FARFilter Filter;
+#if ENGINE_MAJOR_VERSION == 4
 		Filter.ClassNames.Add(UDynamicIdPoolAsset::StaticClass()->GetFName());
+#elif ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 0 || ENGINE_MINOR_VERSION == 1)
+		Filter.ClassNames.Add(UDynamicIdPoolAsset::StaticClass()->GetFName());
+#elif ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+		Filter.ClassPaths.Add(UDynamicIdPoolAsset::StaticClass()->GetClassPathName());
+#endif
 		Filter.bRecursiveClasses = true; // Set to true if you want to include subclasses
 
 		TArray<FAssetData> AssetData;


### PR DESCRIPTION
# Description

Adjusted code for Asset Registry filter to use ClassPaths in UE5.2 and 5.3, and kept ClassName for previous versions. Adjusted formatting for oculus line in build file.

Height Task ID (If applicable): T-5287

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules