### PR TITLE
added pico roomsize

### DIFF
--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/RoomSize.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/RoomSize.cpp
@@ -33,44 +33,49 @@ void URoomSize::OnSessionBegin()
 		FVector size;
 		if (cognitive->TryGetRoomSize(size))
 		{
+			FString description;
+			float floorsize;
 			//if the boundary is stationary, we will get one dimension as 0
 			//so we set a hard-coded room size
 			if (size.X == 0 || size.Y == 0)
 			{
 				size.X = 141.0f;
 				size.Y = 141.0f;
-			}
-			//pico roomscale
-			if (size.X >= 1000 && size.Y >= 1000)
-			{
-				//convert room size to meters
-				float floorsize = (size.X / 100000.0f) * (size.Y / 100000.0f);
-				floorsize = FMath::CeilToInt(floorsize * 100000.0f) / 100000.0f;
 
-				//format description
-				float sizeX = FMath::CeilToInt(size.X) / 100000.0f;
-				float sizeY = FMath::CeilToInt(size.Y) / 100000.0f;
-				FString description = FString::SanitizeFloat(sizeX) + " x " + FString::SanitizeFloat(sizeY);
-
-				//write session properties
-				cognitive->SetSessionProperty("c3d.roomsizeMeters", floorsize);
-				cognitive->SetSessionProperty("c3d.roomsizeDescriptionMeters", description);
-			}
-			else //oculus and others
-			{
-				//convert room size to meters
-				float floorsize = (size.X / 100.0f) * (size.Y / 100.0f);
+				floorsize = (size.X / 100.0f) * (size.Y / 100.0f);
 				floorsize = FMath::CeilToInt(floorsize * 100.0f) / 100.0f;
 
 				//format description
 				float sizeX = FMath::CeilToInt(size.X) / 100.0f;
 				float sizeY = FMath::CeilToInt(size.Y) / 100.0f;
-				FString description = FString::SanitizeFloat(sizeX) + " x " + FString::SanitizeFloat(sizeY);
-
-				//write session properties
-				cognitive->SetSessionProperty("c3d.roomsizeMeters", floorsize);
-				cognitive->SetSessionProperty("c3d.roomsizeDescriptionMeters", description);
+				description = FString::SanitizeFloat(sizeX) + " x " + FString::SanitizeFloat(sizeY);
 			}
+			else
+			{
+#ifdef INCLUDE_PICO_PLUGIN
+				//convert room size to meters
+				floorsize = (size.X / 100000.0f) * (size.Y / 100000.0f);
+				floorsize = FMath::CeilToInt(floorsize * 100000.0f) / 100000.0f;
+
+				//format description
+				float sizeX = FMath::CeilToInt(size.X) / 100000.0f;
+				float sizeY = FMath::CeilToInt(size.Y) / 100000.0f;
+				description = FString::SanitizeFloat(sizeX) + " x " + FString::SanitizeFloat(sizeY);
+#else
+				//convert room size to meters
+				floorsize = (size.X / 100.0f) * (size.Y / 100.0f);
+				floorsize = FMath::CeilToInt(floorsize * 100.0f) / 100.0f;
+
+				//format description
+				float sizeX = FMath::CeilToInt(size.X) / 100.0f;
+				float sizeY = FMath::CeilToInt(size.Y) / 100.0f;
+				description = FString::SanitizeFloat(sizeX) + " x " + FString::SanitizeFloat(sizeY);
+#endif
+			}
+
+			//write session properties
+			cognitive->SetSessionProperty("c3d.roomsizeMeters", floorsize);
+			cognitive->SetSessionProperty("c3d.roomsizeDescriptionMeters", description);
 		}
 	}
 }

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/RoomSize.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/RoomSize.cpp
@@ -40,19 +40,37 @@ void URoomSize::OnSessionBegin()
 				size.X = 141.0f;
 				size.Y = 141.0f;
 			}
+			//pico roomscale
+			if (size.X >= 1000 && size.Y >= 1000)
+			{
+				//convert room size to meters
+				float floorsize = (size.X / 100000.0f) * (size.Y / 100000.0f);
+				floorsize = FMath::CeilToInt(floorsize * 100000.0f) / 100000.0f;
 
-			//convert room size to meters
-			float floorsize = (size.X / 100.0f) * (size.Y / 100.0f);
-			floorsize = FMath::CeilToInt(floorsize * 100.0f) / 100.0f;
+				//format description
+				float sizeX = FMath::CeilToInt(size.X) / 100000.0f;
+				float sizeY = FMath::CeilToInt(size.Y) / 100000.0f;
+				FString description = FString::SanitizeFloat(sizeX) + " x " + FString::SanitizeFloat(sizeY);
 
-			//format description
-			float sizeX = FMath::CeilToInt(size.X) / 100.0f;
-			float sizeY = FMath::CeilToInt(size.Y) / 100.0f;
-			FString description = FString::SanitizeFloat(sizeX) + " x " + FString::SanitizeFloat(sizeY);
+				//write session properties
+				cognitive->SetSessionProperty("c3d.roomsizeMeters", floorsize);
+				cognitive->SetSessionProperty("c3d.roomsizeDescriptionMeters", description);
+			}
+			else //oculus and others
+			{
+				//convert room size to meters
+				float floorsize = (size.X / 100.0f) * (size.Y / 100.0f);
+				floorsize = FMath::CeilToInt(floorsize * 100.0f) / 100.0f;
 
-			//write session properties
-			cognitive->SetSessionProperty("c3d.roomsizeMeters", floorsize);
-			cognitive->SetSessionProperty("c3d.roomsizeDescriptionMeters", description);
+				//format description
+				float sizeX = FMath::CeilToInt(size.X) / 100.0f;
+				float sizeY = FMath::CeilToInt(size.Y) / 100.0f;
+				FString description = FString::SanitizeFloat(sizeX) + " x " + FString::SanitizeFloat(sizeY);
+
+				//write session properties
+				cognitive->SetSessionProperty("c3d.roomsizeMeters", floorsize);
+				cognitive->SetSessionProperty("c3d.roomsizeDescriptionMeters", description);
+			}
 		}
 	}
 }

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/Cognitive3D.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/Cognitive3D.cpp
@@ -1027,6 +1027,13 @@ bool FAnalyticsProviderCognitive3D::TryGetRoomSize(FVector& roomsize)
 	roomsize.Y = BoundaryPoints.Y;
 	return true;
 #endif
+	//pico
+#elif INCLUDE_PICO_PLUGIN
+	FVector BoundaryDimensions = UPICOXRHMDFunctionLibrary::PXR_GetBoundaryDimensions(EPICOXRBoundaryType::PlayArea);
+	roomsize.X = FMath::Abs(BoundaryDimensions.X);
+	roomsize.Y = FMath::Abs(BoundaryDimensions.Y);
+	return true;
+	//crossplatform
 #elif ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION == 27 
 	FVector2D areaBounds = UHeadMountedDisplayFunctionLibrary::GetPlayAreaBounds();
 	roomsize.X = areaBounds.X;

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/Cognitive3D.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/Cognitive3D.cpp
@@ -1028,7 +1028,7 @@ bool FAnalyticsProviderCognitive3D::TryGetRoomSize(FVector& roomsize)
 	return true;
 #endif
 	//pico
-#elif INCLUDE_PICO_PLUGIN
+#elifdef INCLUDE_PICO_PLUGIN
 	FVector BoundaryDimensions = UPICOXRHMDFunctionLibrary::PXR_GetBoundaryDimensions(EPICOXRBoundaryType::PlayArea);
 	roomsize.X = FMath::Abs(BoundaryDimensions.X);
 	roomsize.Y = FMath::Abs(BoundaryDimensions.Y);


### PR DESCRIPTION
# Description

Adding RoomSize property for PicoXR. Currently due to an error on the PicoXR side, it shows the device last-saved roomscale dimensions even if using stationary boundary, so our SDK has no way to tell which one theyre actually using.

Height Task ID(s) (If applicable): T-6464

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
