### PR TITLE
Unreal SDK 1.1.1 hotfix: adjust preprocessor condition

### DIFF
--- a/Cognitive3DTest/Plugins/Cognitive3D/Cognitive3D.uplugin
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Cognitive3D.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.1.0",
+	"VersionName": "1.1.1",
 	"FriendlyName": "Cognitive3D Analytics",
 	"Description": "Cognitive3D Analytics for Unreal",
 	"Category": "Analytics",

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/Cognitive3D.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/Cognitive3D.cpp
@@ -1028,7 +1028,7 @@ bool FAnalyticsProviderCognitive3D::TryGetRoomSize(FVector& roomsize)
 	return true;
 #endif
 	//pico
-#elifdef INCLUDE_PICO_PLUGIN
+#elif defined INCLUDE_PICO_PLUGIN
 	FVector BoundaryDimensions = UPICOXRHMDFunctionLibrary::PXR_GetBoundaryDimensions(EPICOXRBoundaryType::PlayArea);
 	roomsize.X = FMath::Abs(BoundaryDimensions.X);
 	roomsize.Y = FMath::Abs(BoundaryDimensions.Y);

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/Cognitive3D.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/Cognitive3D.h
@@ -15,7 +15,7 @@
 DEFINE_LOG_CATEGORY_STATIC(Cognitive3D_Log, Log, All);
 
 #define Cognitive3D_SDK_NAME "unreal"
-#define Cognitive3D_SDK_VERSION "1.1.0"
+#define Cognitive3D_SDK_VERSION "1.1.1"
 
 class IAnalyticsProvider;
 class FAnalyticsProviderCognitive3D;


### PR DESCRIPTION
# Description

Using #elifdef worked for some versions but not 5.3, changing it to something that works on old and new versions of unreal.

Height Task ID(s) (If applicable):

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
