### PR TITLE
Data frequency and misc fixes

### DIFF
--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/Cognitive3D.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/Cognitive3D.cpp
@@ -807,7 +807,13 @@ void FAnalyticsProviderCognitive3D::CacheSceneData()
 {
 	TArray<FString>scenstrings;
 	FString TestSyncFile = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
+
+#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+	const FString NormalizedTestSyncFile = GConfig->NormalizeConfigIniPath(TestSyncFile);
+	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenstrings, NormalizedTestSyncFile);
+#else
 	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenstrings, TestSyncFile);
+#endif
 	SceneData.Empty();
 
 	for (int i = 0; i < scenstrings.Num(); i++)

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/Cognitive3D.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/Cognitive3D.cpp
@@ -808,7 +808,7 @@ void FAnalyticsProviderCognitive3D::CacheSceneData()
 	TArray<FString>scenstrings;
 	FString TestSyncFile = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
 
-#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 	const FString NormalizedTestSyncFile = GConfig->NormalizeConfigIniPath(TestSyncFile);
 	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenstrings, NormalizedTestSyncFile);
 #else

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/DynamicObject.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/DynamicObject.cpp
@@ -428,51 +428,103 @@ void UDynamicObject::TickComponent( float DeltaTime, ELevelTick TickType, FActor
 	if (SyncUpdateWithPlayer){return;}
 
 	currentTime += DeltaTime;
-	if (currentTime > UpdateInterval)
+	if (IsController)
 	{
-		currentTime -= UpdateInterval;
-
-		//rotation angle to degrees
-		auto parentRotator = GetAttachParent()->GetComponentRotation();
-		float quatDot = parentRotator.Quaternion() | LastRotation;
-		quatDot = FMath::Abs(quatDot);
-		quatDot = FMath::Min(quatDot,1.0f);
-		float quatDegrees = FMath::RadiansToDegrees(FMath::Acos(quatDot)) * 2;
-		bool hasScaleChanged = false;
-
-		if (FMath::Abs(LastScale.Size() - GetAttachParent()->GetComponentTransform().GetScale3D().Size()) > ScaleThreshold)
+		if (currentTime > ControllerUpdateInterval)
 		{
-			hasScaleChanged = true;
-		}
+			currentTime -= ControllerUpdateInterval;
 
-		if (!hasScaleChanged)
-		{
-			if ((LastPosition - GetAttachParent()->GetComponentLocation()).Size() > PositionThreshold)
-			{
-				//moved
-			}
-			else if (quatDegrees > RotationThreshold) //rotator stuff
-			{
-				//rotated
-			}
-			else
-			{
-				//hasn't moved enough
-				return;
-			}
-		}
+			//rotation angle to degrees
+			auto parentRotator = GetAttachParent()->GetComponentRotation();
+			float quatDot = parentRotator.Quaternion() | LastRotation;
+			quatDot = FMath::Abs(quatDot);
+			quatDot = FMath::Min(quatDot, 1.0f);
+			float quatDegrees = FMath::RadiansToDegrees(FMath::Acos(quatDot)) * 2;
+			bool hasScaleChanged = false;
 
-		//scene component
-		LastPosition = GetAttachParent()->GetComponentLocation();
-		LastRotation = GetAttachParent()->GetComponentRotation().Quaternion();
-		if (hasScaleChanged)
-		{
-			LastScale = GetAttachParent()->GetComponentScale();
-		}
+			if (FMath::Abs(LastScale.Size() - GetAttachParent()->GetComponentTransform().GetScale3D().Size()) > ScaleThreshold)
+			{
+				hasScaleChanged = true;
+			}
 
-		FDynamicObjectSnapshot snapObj = MakeSnapshot(hasScaleChanged);
-		dynamicObjectManager->AddSnapshot(snapObj);
+			if (!hasScaleChanged)
+			{
+				if ((LastPosition - GetAttachParent()->GetComponentLocation()).Size() > PositionThreshold)
+				{
+					//moved
+				}
+				else if (quatDegrees > RotationThreshold) //rotator stuff
+				{
+					//rotated
+				}
+				else
+				{
+					//hasn't moved enough
+					return;
+				}
+			}
+
+			//scene component
+			LastPosition = GetAttachParent()->GetComponentLocation();
+			LastRotation = GetAttachParent()->GetComponentRotation().Quaternion();
+			if (hasScaleChanged)
+			{
+				LastScale = GetAttachParent()->GetComponentScale();
+			}
+
+			FDynamicObjectSnapshot snapObj = MakeSnapshot(hasScaleChanged);
+			dynamicObjectManager->AddSnapshot(snapObj);
+		}
 	}
+	else
+	{
+		if (currentTime > DynamicUpdateInterval)
+		{
+			currentTime -= DynamicUpdateInterval;
+
+			//rotation angle to degrees
+			auto parentRotator = GetAttachParent()->GetComponentRotation();
+			float quatDot = parentRotator.Quaternion() | LastRotation;
+			quatDot = FMath::Abs(quatDot);
+			quatDot = FMath::Min(quatDot, 1.0f);
+			float quatDegrees = FMath::RadiansToDegrees(FMath::Acos(quatDot)) * 2;
+			bool hasScaleChanged = false;
+
+			if (FMath::Abs(LastScale.Size() - GetAttachParent()->GetComponentTransform().GetScale3D().Size()) > ScaleThreshold)
+			{
+				hasScaleChanged = true;
+			}
+
+			if (!hasScaleChanged)
+			{
+				if ((LastPosition - GetAttachParent()->GetComponentLocation()).Size() > PositionThreshold)
+				{
+					//moved
+				}
+				else if (quatDegrees > RotationThreshold) //rotator stuff
+				{
+					//rotated
+				}
+				else
+				{
+					//hasn't moved enough
+					return;
+				}
+			}
+
+			//scene component
+			LastPosition = GetAttachParent()->GetComponentLocation();
+			LastRotation = GetAttachParent()->GetComponentRotation().Quaternion();
+			if (hasScaleChanged)
+			{
+				LastScale = GetAttachParent()->GetComponentScale();
+			}
+
+			FDynamicObjectSnapshot snapObj = MakeSnapshot(hasScaleChanged);
+			dynamicObjectManager->AddSnapshot(snapObj);
+		}
+	}
+	
 }
 
 void UDynamicObject::ValidateObjectId()

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/DynamicObject.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/DynamicObject.cpp
@@ -428,101 +428,56 @@ void UDynamicObject::TickComponent( float DeltaTime, ELevelTick TickType, FActor
 	if (SyncUpdateWithPlayer){return;}
 
 	currentTime += DeltaTime;
-	if (IsController)
+
+	if (currentTime > ControllerUpdateInterval)
 	{
-		if (currentTime > ControllerUpdateInterval)
-		{
+		
+		if (IsController)
 			currentTime -= ControllerUpdateInterval;
-
-			//rotation angle to degrees
-			auto parentRotator = GetAttachParent()->GetComponentRotation();
-			float quatDot = parentRotator.Quaternion() | LastRotation;
-			quatDot = FMath::Abs(quatDot);
-			quatDot = FMath::Min(quatDot, 1.0f);
-			float quatDegrees = FMath::RadiansToDegrees(FMath::Acos(quatDot)) * 2;
-			bool hasScaleChanged = false;
-
-			if (FMath::Abs(LastScale.Size() - GetAttachParent()->GetComponentTransform().GetScale3D().Size()) > ScaleThreshold)
-			{
-				hasScaleChanged = true;
-			}
-
-			if (!hasScaleChanged)
-			{
-				if ((LastPosition - GetAttachParent()->GetComponentLocation()).Size() > PositionThreshold)
-				{
-					//moved
-				}
-				else if (quatDegrees > RotationThreshold) //rotator stuff
-				{
-					//rotated
-				}
-				else
-				{
-					//hasn't moved enough
-					return;
-				}
-			}
-
-			//scene component
-			LastPosition = GetAttachParent()->GetComponentLocation();
-			LastRotation = GetAttachParent()->GetComponentRotation().Quaternion();
-			if (hasScaleChanged)
-			{
-				LastScale = GetAttachParent()->GetComponentScale();
-			}
-
-			FDynamicObjectSnapshot snapObj = MakeSnapshot(hasScaleChanged);
-			dynamicObjectManager->AddSnapshot(snapObj);
-		}
-	}
-	else
-	{
-		if (currentTime > DynamicUpdateInterval)
-		{
+		else
 			currentTime -= DynamicUpdateInterval;
 
-			//rotation angle to degrees
-			auto parentRotator = GetAttachParent()->GetComponentRotation();
-			float quatDot = parentRotator.Quaternion() | LastRotation;
-			quatDot = FMath::Abs(quatDot);
-			quatDot = FMath::Min(quatDot, 1.0f);
-			float quatDegrees = FMath::RadiansToDegrees(FMath::Acos(quatDot)) * 2;
-			bool hasScaleChanged = false;
+		//rotation angle to degrees
+		auto parentRotator = GetAttachParent()->GetComponentRotation();
+		float quatDot = parentRotator.Quaternion() | LastRotation;
+		quatDot = FMath::Abs(quatDot);
+		quatDot = FMath::Min(quatDot, 1.0f);
+		float quatDegrees = FMath::RadiansToDegrees(FMath::Acos(quatDot)) * 2;
+		bool hasScaleChanged = false;
 
-			if (FMath::Abs(LastScale.Size() - GetAttachParent()->GetComponentTransform().GetScale3D().Size()) > ScaleThreshold)
-			{
-				hasScaleChanged = true;
-			}
-
-			if (!hasScaleChanged)
-			{
-				if ((LastPosition - GetAttachParent()->GetComponentLocation()).Size() > PositionThreshold)
-				{
-					//moved
-				}
-				else if (quatDegrees > RotationThreshold) //rotator stuff
-				{
-					//rotated
-				}
-				else
-				{
-					//hasn't moved enough
-					return;
-				}
-			}
-
-			//scene component
-			LastPosition = GetAttachParent()->GetComponentLocation();
-			LastRotation = GetAttachParent()->GetComponentRotation().Quaternion();
-			if (hasScaleChanged)
-			{
-				LastScale = GetAttachParent()->GetComponentScale();
-			}
-
-			FDynamicObjectSnapshot snapObj = MakeSnapshot(hasScaleChanged);
-			dynamicObjectManager->AddSnapshot(snapObj);
+		if (FMath::Abs(LastScale.Size() - GetAttachParent()->GetComponentTransform().GetScale3D().Size()) > ScaleThreshold)
+		{
+			hasScaleChanged = true;
 		}
+
+		if (!hasScaleChanged)
+		{
+			if ((LastPosition - GetAttachParent()->GetComponentLocation()).Size() > PositionThreshold)
+			{
+				//moved
+			}
+			else if (quatDegrees > RotationThreshold) //rotator stuff
+			{
+				//rotated
+			}
+			else
+			{
+				//hasn't moved enough
+				return;
+			}
+		}
+
+		//scene component
+		LastPosition = GetAttachParent()->GetComponentLocation();
+		LastRotation = GetAttachParent()->GetComponentRotation().Quaternion();
+		if (hasScaleChanged)
+		{
+			LastScale = GetAttachParent()->GetComponentScale();
+		}
+
+		FDynamicObjectSnapshot snapObj = MakeSnapshot(hasScaleChanged);
+		dynamicObjectManager->AddSnapshot(snapObj);
+		
 	}
 	
 }

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/DynamicObject.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/DynamicObject.h
@@ -102,7 +102,7 @@ public:
 		float ControllerUpdateInterval = 0.1;
 
 	UPROPERTY(EditAnywhere, AdvancedDisplay, Category = "Cognitive3D Analytics")
-		float DynamicUpdateInterval = 1.0;
+		float DynamicUpdateInterval = 0.1;
 
 	//distance in cm the object needs to move before sending an update
 	UPROPERTY(EditAnywhere, AdvancedDisplay, Category = "Cognitive3D Analytics")

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/DynamicObject.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/DynamicObject.h
@@ -99,7 +99,10 @@ public:
 
 	//time in seconds between checking if position and rotation updates need to be recorded
 	UPROPERTY(EditAnywhere, AdvancedDisplay, Category = "Cognitive3D Analytics")
-		float UpdateInterval = 0.1;
+		float ControllerUpdateInterval = 0.1;
+
+	UPROPERTY(EditAnywhere, AdvancedDisplay, Category = "Cognitive3D Analytics")
+		float DynamicUpdateInterval = 1.0;
 
 	//distance in cm the object needs to move before sending an update
 	UPROPERTY(EditAnywhere, AdvancedDisplay, Category = "Cognitive3D Analytics")

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/Cognitive3DEditorModule.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/Cognitive3DEditorModule.cpp
@@ -60,7 +60,7 @@ void FCognitive3DEditorModule::StartupModule()
 	FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
 	FCognitiveEditorTools::Initialize();
 
-#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 	const FString NormalizedEngineIni = GConfig->NormalizeConfigIniPath(EngineIni);
 	const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/Cognitive3DEditorModule.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/Cognitive3DEditorModule.cpp
@@ -58,12 +58,22 @@ void FCognitive3DEditorModule::StartupModule()
 
 	FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
 	FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
+	FCognitiveEditorTools::Initialize();
 
-	FCognitiveEditorTools::Initialize();	
+#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+	const FString NormalizedEngineIni = GConfig->NormalizeConfigIniPath(EngineIni);
+	const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
+
+	GConfig->GetString(TEXT("Analytics"), TEXT("ApiKey"), FCognitiveEditorTools::GetInstance()->ApplicationKey, NormalizedEngineIni);
+	GConfig->GetString(TEXT("Analytics"), TEXT("AttributionKey"), FCognitiveEditorTools::GetInstance()->AttributionKey, NormalizedEngineIni);
+	GConfig->GetString(TEXT("Analytics"), TEXT("DeveloperKey"), FCognitiveEditorTools::GetInstance()->DeveloperKey, NormalizedEditorIni);
+	GConfig->GetString(TEXT("Analytics"), TEXT("ExportPath"), FCognitiveEditorTools::GetInstance()->BaseExportDirectory, NormalizedEditorIni);
+#else
 	GConfig->GetString(TEXT("Analytics"), TEXT("ApiKey"), FCognitiveEditorTools::GetInstance()->ApplicationKey, EngineIni);
 	GConfig->GetString(TEXT("Analytics"), TEXT("AttributionKey"), FCognitiveEditorTools::GetInstance()->AttributionKey, EngineIni);
 	GConfig->GetString(TEXT("Analytics"), TEXT("DeveloperKey"), FCognitiveEditorTools::GetInstance()->DeveloperKey, EditorIni);
 	GConfig->GetString(TEXT("Analytics"), TEXT("ExportPath"), FCognitiveEditorTools::GetInstance()->BaseExportDirectory, EditorIni);
+#endif // ENGINE_MAJOR_VERSION == 4
 
 	//add actions for the dynamic object id pool asset
 	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
@@ -2795,6 +2795,7 @@ void FCognitiveEditorTools::ValidateGeneratedFiles()
 		if (!FoundErrorFile)
 		{
 			UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::ExportScene verified generated files"));
+			WizardUploadError = "";
 		}
 		
 	}
@@ -2905,6 +2906,8 @@ void FCognitiveEditorTools::GenerateSettingsJsonFile()
 	bool writeSettingsJsonSuccess = FFileHelper::SaveStringToFile(settingsContents, *settingsFullPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
 	if (writeSettingsJsonSuccess == false)
 	{
+		WizardUploadResponseCode = 0;
+		WizardUploadError = "FCognitiveEditorTools::ExportScene unable to save settings.json";
 		UE_LOG(LogTemp, Error, TEXT("FCognitiveEditorTools::ExportScene unable to save settings.json"));
 	}
 }
@@ -2947,6 +2950,8 @@ void FCognitiveEditorTools::WizardUpload()
 
 	if (!HasSettingsJsonFile())
 	{
+		WizardUploadResponseCode = 0;
+		WizardUploadError = "FCognitiveEditorToolsCustomization::WizardUpload settings.json file missing! Creating for current scene";
 		UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorToolsCustomization::WizardUpload settings.json file missing! Creating for current scene"));
 		GenerateSettingsJsonFile();
 	}
@@ -2963,6 +2968,7 @@ void FCognitiveEditorTools::SetDefaultIfNoExportDirectory()
 {
 	if (BaseExportDirectory.Len() == 0)
 	{
+		WizardUploadError = "";
 		BaseExportDirectory = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("TEMP_C3D_Export/"));
 	}
 }

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
@@ -1683,7 +1683,6 @@ void FCognitiveEditorTools::OnUploadSceneCompleted(FHttpRequestPtr Request, FHtt
 	if (bWasSuccessful)
 	{
 		GLog->Log("FCognitiveEditorTools::OnUploadSceneCompleted response code " + FString::FromInt(Response->GetResponseCode()));
-		ShowNotification(TEXT("Scene Uploaded Successfully"));
 	}
 	else
 	{
@@ -1697,6 +1696,7 @@ void FCognitiveEditorTools::OnUploadSceneCompleted(FHttpRequestPtr Request, FHtt
 
 	if (bWasSuccessful && Response->GetResponseCode() < 300)
 	{
+		ShowNotification(TEXT("Scene Uploaded Successfully"));
 		//UE_LOG(LogTemp, Warning, TEXT("Upload Scene Response is %s"), *Response->GetContentAsString());
 
 		UWorld* myworld = GWorld->GetWorld();
@@ -1730,6 +1730,7 @@ void FCognitiveEditorTools::OnUploadSceneCompleted(FHttpRequestPtr Request, FHtt
 	}
 	else
 	{
+		ShowNotification(TEXT("Failed to upload scene"), false);
 		WizardUploading = false;
 		WizardUploadError = "FCognitiveEditorTools::OnUploadSceneCompleted response code " + FString::FromInt(Response->GetResponseCode());
 	}

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
@@ -168,6 +168,49 @@ void FCognitiveEditorTools::CheckIniConfigured()
 	}
 
 	FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
+
+#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+	const FString NormalizedEngineIni = GConfig->NormalizeConfigIniPath(EngineIni);
+
+	GConfig->Flush(true, NormalizedEngineIni);
+	FString tempGatewaydefault;
+	GConfig->GetString(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("Gateway"), tempGatewaydefault, NormalizedEngineIni);
+
+	if (tempGatewaydefault.IsEmpty())
+	{
+		GLog->Log("FCognitiveEditorTools::CheckIniConfigured write defaults to ini");
+		FString defaultgateway = "data.cognitive3d.com";
+		FString trueString = "True";
+		GConfig->SetString(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("Gateway"), *defaultgateway, NormalizedEngineIni);
+
+		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("GazeBatchSize"), 256, NormalizedEngineIni);
+
+		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("CustomEventBatchSize"), 256, NormalizedEngineIni);
+		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("CustomEventAutoTimer"), 10, NormalizedEngineIni);
+
+		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("DynamicDataLimit"), 512, NormalizedEngineIni);
+		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("DynamicAutoTimer"), 10, NormalizedEngineIni);
+
+		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("SensorDataLimit"), 512, NormalizedEngineIni);
+		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("SensorAutoTimer"), 10, NormalizedEngineIni);
+
+		GConfig->SetString(TEXT("Analytics"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), NormalizedEngineIni);
+		GConfig->SetString(TEXT("AnalyticsDebug"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), NormalizedEngineIni);
+		GConfig->SetString(TEXT("AnalyticsTest"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), NormalizedEngineIni);
+		GConfig->SetString(TEXT("AnalyticsDevelopment"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), NormalizedEngineIni);
+
+		GConfig->SetString(TEXT("Analytics"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), NormalizedEngineIni);
+		GConfig->SetString(TEXT("AnalyticsDebug"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), NormalizedEngineIni);
+		GConfig->SetString(TEXT("AnalyticsTest"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), NormalizedEngineIni);
+		GConfig->SetString(TEXT("AnalyticsDevelopment"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), NormalizedEngineIni);
+
+		GConfig->SetString(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("EnableLocalCache"), *trueString, NormalizedEngineIni);
+		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("LocalCacheSize"), 100, NormalizedEngineIni);
+		GConfig->Flush(false, NormalizedEngineIni);
+	}
+
+#else
+
 	GConfig->Flush(true, EngineIni);
 	FString tempGatewaydefault;
 	GConfig->GetString(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("Gateway"), tempGatewaydefault, EngineIni);
@@ -204,6 +247,7 @@ void FCognitiveEditorTools::CheckIniConfigured()
 		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("LocalCacheSize"), 100, EngineIni);
 		GConfig->Flush(false, EngineIni);
 	}
+#endif
 }
 
 //at any step in the uploading process
@@ -1337,14 +1381,26 @@ FReply FCognitiveEditorTools::SelectBaseExportDirectory()
 	{
 		BaseExportDirectory = outFilename;
 		FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
+		
+#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+		const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
+		GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, NormalizedEditorIni);
+#else
 		GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, EditorIni);
+#endif
 	}
 	else
 	{
 		//set default export directory if it isnt set
 		SetDefaultIfNoExportDirectory();
 		FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
+
+#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+		const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
+		GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, NormalizedEditorIni);
+#else
 		GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, EditorIni);
+#endif
 	}
 	return FReply::Handled();
 }
@@ -2302,6 +2358,12 @@ void FCognitiveEditorTools::ReadSceneDataFromFile()
 	FString TestSyncFile = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
 	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenstrings, TestSyncFile);
 
+#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+	const FString NormalizedTestSyncFile = GConfig->NormalizeConfigIniPath(TestSyncFile);
+	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenstrings, NormalizedTestSyncFile);
+#else
+	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenstrings, TestSyncFile);
+#endif
 	for (int32 i = 0; i < scenstrings.Num(); i++)
 	{
 		TArray<FString> Array;
@@ -2435,6 +2497,12 @@ void FCognitiveEditorTools::SceneVersionResponse(FHttpRequestPtr Request, FHttpR
 		FString TestSyncFile = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
 		GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, TestSyncFile);
 
+#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+		const FString NormalizedTestSyncFile = GConfig->NormalizeConfigIniPath(TestSyncFile);
+		GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, NormalizedTestSyncFile);
+#else
+		GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, TestSyncFile);
+#endif
 		//GLog->Log("found this many scene datas in ini " + FString::FromInt(iniscenedata.Num()));
 		//GLog->Log("looking for scene " + currentSceneData->Name);
 
@@ -2463,6 +2531,13 @@ void FCognitiveEditorTools::SceneVersionResponse(FHttpRequestPtr Request, FHttpR
 
 		GLog->Log("FCognitiveTools::SceneVersionResponse successful. Write scene data to config file");
 
+#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+		//set array to config
+		GConfig->RemoveKey(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), NormalizedTestSyncFile);
+		GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, NormalizedTestSyncFile);
+
+		GConfig->Flush(false, NormalizedTestSyncFile);
+#else
 		//set array to config
 		GConfig->RemoveKey(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), TestSyncFile);
 		GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, TestSyncFile);
@@ -2475,6 +2550,7 @@ void FCognitiveEditorTools::SceneVersionResponse(FHttpRequestPtr Request, FHttpR
 
 		GConfig->Flush(false, TestSyncFile);
 		//GConfig->LoadFile(TestSyncFile);
+#endif
 		ConfigFileHasChanged = true;
 		ReadSceneDataFromFile();
 
@@ -2504,12 +2580,25 @@ FReply FCognitiveEditorTools::SaveAPIDeveloperKeysToFile()
 {
 	FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
 	FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
+
+#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+	const FString NormalizedEngineIni = GConfig->NormalizeConfigIniPath(EngineIni);
+	const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
+
+	GConfig->SetString(TEXT("Analytics"), TEXT("ApiKey"), *ApplicationKey, NormalizedEngineIni);
+	GConfig->SetString(TEXT("Analytics"), TEXT("AttributionKey"), *AttributionKey, NormalizedEngineIni);
+	GConfig->SetString(TEXT("Analytics"), TEXT("DeveloperKey"), *DeveloperKey, NormalizedEditorIni);
+
+	GConfig->Flush(false, NormalizedEngineIni);
+	GConfig->Flush(false, NormalizedEditorIni);
+#else
 	GConfig->SetString(TEXT("Analytics"), TEXT("ApiKey"), *ApplicationKey, EngineIni);
 	GConfig->SetString(TEXT("Analytics"), TEXT("AttributionKey"), *AttributionKey, EngineIni);
 	GConfig->SetString(TEXT("Analytics"), TEXT("DeveloperKey"), *DeveloperKey, EditorIni);
 
 	GConfig->Flush(false, GEngineIni);
 	GConfig->Flush(false, GEditorIni);
+#endif
 	ConfigFileHasChanged = true;
 
 	return FReply::Handled();
@@ -2518,8 +2607,17 @@ FReply FCognitiveEditorTools::SaveAPIDeveloperKeysToFile()
 void FCognitiveEditorTools::SaveApplicationKeyToFile(FString key)
 {
 	FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
+
+#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+	const FString NormalizedEngineIni = GConfig->NormalizeConfigIniPath(EngineIni);
+
+	GConfig->SetString(TEXT("Analytics"), TEXT("ApiKey"), *key, NormalizedEngineIni);
+	GConfig->Flush(false, NormalizedEngineIni);
+#else
 	GConfig->SetString(TEXT("Analytics"), TEXT("ApiKey"), *key, EngineIni);
 	GConfig->Flush(false, GEngineIni);
+#endif
+
 	ConfigFileHasChanged = true;
 
 	ApplicationKey = key;
@@ -2528,8 +2626,17 @@ void FCognitiveEditorTools::SaveApplicationKeyToFile(FString key)
 void FCognitiveEditorTools::SaveDeveloperKeyToFile(FString key)
 {
 	FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
+
+#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+	const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
+
+	GConfig->SetString(TEXT("Analytics"), TEXT("DeveloperKey"), *key, NormalizedEditorIni);
+	GConfig->Flush(false, NormalizedEditorIni);
+#else
 	GConfig->SetString(TEXT("Analytics"), TEXT("DeveloperKey"), *key, EditorIni);
 	GConfig->Flush(false, GEngineIni);
+#endif
+
 	ConfigFileHasChanged = true;
 
 	DeveloperKey = key;
@@ -2570,7 +2677,14 @@ void FCognitiveEditorTools::SaveSceneData(FString sceneName, FString sceneKey)
 	TArray<FString> scenePairs = TArray<FString>();
 
 	FString TestSyncFile = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
+
+#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+	const FString NormalizedTestSyncFile = GConfig->NormalizeConfigIniPath(TestSyncFile);
+
+	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenePairs, NormalizedTestSyncFile);
+#lese
 	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenePairs, TestSyncFile);
+#endif
 
 	bool didSetKey = false;
 	for (int32 i = 0; i < scenePairs.Num(); i++)
@@ -2603,9 +2717,15 @@ void FCognitiveEditorTools::SaveSceneData(FString sceneName, FString sceneKey)
 		}
 	}
 
+#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+	GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenePairs, NormalizedTestSyncFile);
+
+	GConfig->Flush(false, NormalizedTestSyncFile);
+#else
 	GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenePairs, TestSyncFile);
 
 	GConfig->Flush(false, GEngineIni);
+#endif
 }
 
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
@@ -169,7 +169,7 @@ void FCognitiveEditorTools::CheckIniConfigured()
 
 	FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
 
-#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 	const FString NormalizedEngineIni = GConfig->NormalizeConfigIniPath(EngineIni);
 
 	GConfig->Flush(true, NormalizedEngineIni);
@@ -1382,7 +1382,7 @@ FReply FCognitiveEditorTools::SelectBaseExportDirectory()
 		BaseExportDirectory = outFilename;
 		FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
 		
-#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 		const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
 		GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, NormalizedEditorIni);
 #else
@@ -1395,7 +1395,7 @@ FReply FCognitiveEditorTools::SelectBaseExportDirectory()
 		SetDefaultIfNoExportDirectory();
 		FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
 
-#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 		const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
 		GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, NormalizedEditorIni);
 #else
@@ -2356,9 +2356,8 @@ void FCognitiveEditorTools::ReadSceneDataFromFile()
 
 	TArray<FString>scenstrings;
 	FString TestSyncFile = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
-	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenstrings, TestSyncFile);
 
-#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 	const FString NormalizedTestSyncFile = GConfig->NormalizeConfigIniPath(TestSyncFile);
 	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenstrings, NormalizedTestSyncFile);
 #else
@@ -2495,9 +2494,8 @@ void FCognitiveEditorTools::SceneVersionResponse(FHttpRequestPtr Request, FHttpR
 		TArray<FString> iniscenedata;
 
 		FString TestSyncFile = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
-		GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, TestSyncFile);
 
-#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 		const FString NormalizedTestSyncFile = GConfig->NormalizeConfigIniPath(TestSyncFile);
 		GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, NormalizedTestSyncFile);
 #else
@@ -2531,7 +2529,7 @@ void FCognitiveEditorTools::SceneVersionResponse(FHttpRequestPtr Request, FHttpR
 
 		GLog->Log("FCognitiveTools::SceneVersionResponse successful. Write scene data to config file");
 
-#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 		//set array to config
 		GConfig->RemoveKey(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), NormalizedTestSyncFile);
 		GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, NormalizedTestSyncFile);
@@ -2581,7 +2579,7 @@ FReply FCognitiveEditorTools::SaveAPIDeveloperKeysToFile()
 	FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
 	FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
 
-#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 	const FString NormalizedEngineIni = GConfig->NormalizeConfigIniPath(EngineIni);
 	const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
 
@@ -2608,7 +2606,7 @@ void FCognitiveEditorTools::SaveApplicationKeyToFile(FString key)
 {
 	FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
 
-#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 	const FString NormalizedEngineIni = GConfig->NormalizeConfigIniPath(EngineIni);
 
 	GConfig->SetString(TEXT("Analytics"), TEXT("ApiKey"), *key, NormalizedEngineIni);
@@ -2627,7 +2625,7 @@ void FCognitiveEditorTools::SaveDeveloperKeyToFile(FString key)
 {
 	FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
 
-#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 	const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
 
 	GConfig->SetString(TEXT("Analytics"), TEXT("DeveloperKey"), *key, NormalizedEditorIni);
@@ -2678,7 +2676,7 @@ void FCognitiveEditorTools::SaveSceneData(FString sceneName, FString sceneKey)
 
 	FString TestSyncFile = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
 
-#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 	const FString NormalizedTestSyncFile = GConfig->NormalizeConfigIniPath(TestSyncFile);
 
 	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenePairs, NormalizedTestSyncFile);
@@ -2717,7 +2715,7 @@ void FCognitiveEditorTools::SaveSceneData(FString sceneName, FString sceneKey)
 		}
 	}
 
-#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 	GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenePairs, NormalizedTestSyncFile);
 
 	GConfig->Flush(false, NormalizedTestSyncFile);

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
@@ -2680,7 +2680,7 @@ void FCognitiveEditorTools::SaveSceneData(FString sceneName, FString sceneKey)
 	const FString NormalizedTestSyncFile = GConfig->NormalizeConfigIniPath(TestSyncFile);
 
 	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenePairs, NormalizedTestSyncFile);
-#lese
+#else
 	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenePairs, TestSyncFile);
 #endif
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.h
@@ -16,6 +16,7 @@
 #include "UnrealEd.h"
 #include "Misc/FileHelper.h"
 #include "Misc/ScopedSlowTask.h"
+#include "Misc/LocalTimestampDirectoryVisitor.h"
 #include "BusyCursor.h"
 #include "Classes/Components/SceneComponent.h"
 #include "EngineUtils.h"

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveSettingsCustomization.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveSettingsCustomization.cpp
@@ -232,7 +232,7 @@ void ICognitiveSettingsCustomization::CustomizeDetails(IDetailLayoutBuilder& Det
 	FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
 	FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
 
-#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 	const FString NormalizedEngineIni = GConfig->NormalizeConfigIniPath(EngineIni);
 	const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveSettingsCustomization.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveSettingsCustomization.cpp
@@ -232,9 +232,18 @@ void ICognitiveSettingsCustomization::CustomizeDetails(IDetailLayoutBuilder& Det
 	FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
 	FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
 
+#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+	const FString NormalizedEngineIni = GConfig->NormalizeConfigIniPath(EngineIni);
+	const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
+
+	GConfig->GetString(TEXT("Analytics"), TEXT("AttributionKey"), FCognitiveEditorTools::GetInstance()->AttributionKey, NormalizedEngineIni);
+	GConfig->GetString(TEXT("Analytics"), TEXT("ApiKey"), FCognitiveEditorTools::GetInstance()->ApplicationKey, NormalizedEngineIni);
+	GConfig->GetString(TEXT("Analytics"), TEXT("DeveloperKey"), FCognitiveEditorTools::GetInstance()->DeveloperKey, NormalizedEditorIni);
+#else
 	GConfig->GetString(TEXT("Analytics"), TEXT("AttributionKey"), FCognitiveEditorTools::GetInstance()->AttributionKey, EngineIni);
 	GConfig->GetString(TEXT("Analytics"), TEXT("ApiKey"), FCognitiveEditorTools::GetInstance()->ApplicationKey, EngineIni);
 	GConfig->GetString(TEXT("Analytics"), TEXT("DeveloperKey"), FCognitiveEditorTools::GetInstance()->DeveloperKey, EditorIni);
+#endif
 }
 
 TSharedRef<ITableRow> ICognitiveSettingsCustomization::OnGenerateWorkspaceRow(TSharedPtr<FEditorSceneData> InItem, const TSharedRef<STableViewBase>& OwnerTable)

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
@@ -1319,8 +1319,9 @@ bool SSceneSetupWidget::NextButtonEnabled() const
 
 	if (CurrentPageEnum == ESceneSetupPage::Export)
 	{
-		//disable if no scene has been exported
-		if (FCognitiveEditorTools::GetInstance()->GetSceneExportFileCount() == 0)
+		//disable if no scene has been exported or if no settings json file generated
+		if (FCognitiveEditorTools::GetInstance()->GetSceneExportFileCount() == 0 
+			|| FCognitiveEditorTools::GetInstance()->HasSettingsJsonFile() == false)
 		{
 			return false;
 		}

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
@@ -1586,7 +1586,7 @@ EVisibility SSceneSetupWidget::GetAppendedInputsFoundHidden() const
 	//TODO IMPROVEMENT instead of hard coding strings here, should append a list from the resources folder
 	TArray<FString> actionMapping;
 
-#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 	const FString NormalizedInputIni = GConfig->NormalizeConfigIniPath(InputIni);
 	GConfig->GetArray(TEXT("/Script/Engine.InputSettings"), TEXT("+ActionMappings"), actionMapping, NormalizedInputIni);
 #else
@@ -1611,7 +1611,7 @@ EVisibility SSceneSetupWidget::GetAppendedInputsFoundVisibility() const
 	//TODO IMPROVEMENT instead of hard coding strings here, should append a list from the resources folder
 	TArray<FString> actionMapping;
 
-#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 	const FString NormalizedInputIni = GConfig->NormalizeConfigIniPath(InputIni);
 	GConfig->GetArray(TEXT("/Script/Engine.InputSettings"), TEXT("+ActionMappings"), actionMapping, NormalizedInputIni);
 #else
@@ -1634,7 +1634,7 @@ FReply SSceneSetupWidget::AppendInputs()
 	TArray<FString> actionMapping;
 	TArray<FString> axisMapping;
 
-#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 	const FString NormalizedInputIni = GConfig->NormalizeConfigIniPath(InputIni);
 	GConfig->GetArray(TEXT("/Script/Engine.InputSettings"), TEXT("+ActionMappings"), actionMapping, NormalizedInputIni);
 	GConfig->GetArray(TEXT("/Script/Engine.InputSettings"), TEXT("+AxisMappings"), axisMapping, NormalizedInputIni);
@@ -1763,7 +1763,7 @@ FReply SSceneSetupWidget::AppendInputs()
 	axisMapping.Add("(AxisName=\"C3D_RightTriggerAxis\",Scale=1.000000,Key=MixedReality_Right_Trigger_Axis)");
 	axisMapping.Add("(AxisName=\"C3D_RightTriggerAxis\",Scale=1.000000,Key=Vive_Right_Trigger_Axis)");
 
-#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 	GConfig->SetArray(TEXT("/Script/Engine.InputSettings"), TEXT("+ActionMappings"), actionMapping, NormalizedInputIni);
 	GConfig->SetArray(TEXT("/Script/Engine.InputSettings"), TEXT("+AxisMappings"), axisMapping, NormalizedInputIni);
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
@@ -1199,6 +1199,10 @@ FText SSceneSetupWidget::GetNextButtonTooltipText() const
 		{
 			return FText::FromString("You must export the scene geometry to continue");
 		}
+		else if (FCognitiveEditorTools::GetInstance()->HasSettingsJsonFile() == false)
+		{
+			return FText::FromString("settings.json not found in export directory, please try exporting the level again");
+		}
 	}
 	return FText::FromString("");
 }

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
@@ -1585,7 +1585,14 @@ EVisibility SSceneSetupWidget::GetAppendedInputsFoundHidden() const
 	FString InputIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultInput.ini"));
 	//TODO IMPROVEMENT instead of hard coding strings here, should append a list from the resources folder
 	TArray<FString> actionMapping;
+
+#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+	const FString NormalizedInputIni = GConfig->NormalizeConfigIniPath(InputIni);
+	GConfig->GetArray(TEXT("/Script/Engine.InputSettings"), TEXT("+ActionMappings"), actionMapping, NormalizedInputIni);
+#else
 	GConfig->GetArray(TEXT("/Script/Engine.InputSettings"), TEXT("+ActionMappings"), actionMapping, InputIni);
+#endif
+
 	if (actionMapping.Contains("(ActionName=\"C3D_LeftGrip\",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=OculusTouch_Left_Grip_Click)"))
 	{
 		return EVisibility::Collapsed;
@@ -1603,7 +1610,14 @@ EVisibility SSceneSetupWidget::GetAppendedInputsFoundVisibility() const
 	FString InputIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultInput.ini"));
 	//TODO IMPROVEMENT instead of hard coding strings here, should append a list from the resources folder
 	TArray<FString> actionMapping;
+
+#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+	const FString NormalizedInputIni = GConfig->NormalizeConfigIniPath(InputIni);
+	GConfig->GetArray(TEXT("/Script/Engine.InputSettings"), TEXT("+ActionMappings"), actionMapping, NormalizedInputIni);
+#else
 	GConfig->GetArray(TEXT("/Script/Engine.InputSettings"), TEXT("+ActionMappings"), actionMapping, InputIni);
+#endif
+
 	if (actionMapping.Contains("(ActionName=\"C3D_LeftGrip\",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=OculusTouch_Left_Grip_Click)"))
 	{
 		return EVisibility::Visible;
@@ -1620,8 +1634,14 @@ FReply SSceneSetupWidget::AppendInputs()
 	TArray<FString> actionMapping;
 	TArray<FString> axisMapping;
 
+#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+	const FString NormalizedInputIni = GConfig->NormalizeConfigIniPath(InputIni);
+	GConfig->GetArray(TEXT("/Script/Engine.InputSettings"), TEXT("+ActionMappings"), actionMapping, NormalizedInputIni);
+	GConfig->GetArray(TEXT("/Script/Engine.InputSettings"), TEXT("+AxisMappings"), axisMapping, NormalizedInputIni);
+#else
 	GConfig->GetArray(TEXT("/Script/Engine.InputSettings"), TEXT("+ActionMappings"), actionMapping, InputIni);
 	GConfig->GetArray(TEXT("/Script/Engine.InputSettings"), TEXT("+AxisMappings"), axisMapping, InputIni);
+#endif
 
 	if (actionMapping.Contains("(ActionName=\"C3D_LeftGrip\",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=OculusTouch_Left_Grip_Click)"))
 	{
@@ -1743,10 +1763,17 @@ FReply SSceneSetupWidget::AppendInputs()
 	axisMapping.Add("(AxisName=\"C3D_RightTriggerAxis\",Scale=1.000000,Key=MixedReality_Right_Trigger_Axis)");
 	axisMapping.Add("(AxisName=\"C3D_RightTriggerAxis\",Scale=1.000000,Key=Vive_Right_Trigger_Axis)");
 
+#if ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3)
+	GConfig->SetArray(TEXT("/Script/Engine.InputSettings"), TEXT("+ActionMappings"), actionMapping, NormalizedInputIni);
+	GConfig->SetArray(TEXT("/Script/Engine.InputSettings"), TEXT("+AxisMappings"), axisMapping, NormalizedInputIni);
+
+	GConfig->Flush(false, NormalizedInputIni);
+#else
 	GConfig->SetArray(TEXT("/Script/Engine.InputSettings"), TEXT("+ActionMappings"), actionMapping, InputIni);
 	GConfig->SetArray(TEXT("/Script/Engine.InputSettings"), TEXT("+AxisMappings"), axisMapping, InputIni);
 
 	GConfig->Flush(false, InputIni);
+#endif
 
 	GLog->Log("SSceneSetupWidget::AppendInputs complete");
 


### PR DESCRIPTION
# Description

Upload error disappears when appropriate, same with the newly added missing settings.json error message in scene setup. Prevent the spamming of console about input.ini in 5.2 onward. Adjusted scene setup UX to prevent progress when settings.json is missing. Make sure notifications are not appearing when not appropriate for scene upload. Adjusting tooltips and next button usability when there are export errors.

Height Task ID(s) (If applicable): T-7349, T-7244, T-7243, T-5651, T-4481

## Type of change

> Note: delete the lines that are not applicable and check the boxes (add a capital "X" in the square brackets) for the type of change.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
