### PR TITLE
fix sceneload event name and dynamic writing to wrong json, fix duplicate dynamics

### DIFF
--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/PlayerTracker.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/PlayerTracker.h
@@ -13,7 +13,6 @@
 //#include "Engine/Texture2D.h"
 #include "SceneView.h"
 //#include "Engine/TextureRenderTarget2D.h"
-#include "Cognitive3D/Public/DynamicObject.h"
 #include "Runtime/HeadMountedDisplay/Public/IXRTrackingSystem.h"
 #include "Widgets/Text/STextBlock.h"
 #if defined TOBII_EYETRACKING_ACTIVE
@@ -53,6 +52,7 @@
 
 class FAnalyticsProviderCognitive3D;
 class UCognitive3DBlueprints;
+class UDynamicObject;
 
 UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
 class COGNITIVE3D_API UPlayerTracker : public UActorComponent

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/Cognitive3D.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/Cognitive3D.cpp
@@ -194,7 +194,7 @@ void FAnalyticsProviderCognitive3D::HandlePostLevelLoad(UWorld* world)
 		TSharedPtr<FJsonObject> lastsceneproperties = MakeShareable(new FJsonObject());
 		lastsceneproperties->SetStringField("Scene Name", FString(LastSceneData->Name));
 		lastsceneproperties->SetStringField("Scene Id", FString(LastSceneData->Id));
-		customEventRecorder->Send("c3d.SceneUnloaded", lastsceneproperties);
+		customEventRecorder->Send("c3d.SceneUnload", lastsceneproperties);
 	}
 
 	if (currentSceneData.IsValid()) //currently has valid scene data
@@ -207,9 +207,12 @@ void FAnalyticsProviderCognitive3D::HandlePostLevelLoad(UWorld* world)
 		}
 		float duration = FUtil::GetTimestamp() - SceneStartTime;
 		properties->SetNumberField("Duration", duration);
-		customEventRecorder->Send("c3d.SceneLoaded", properties);
-		FlushAndCacheEvents();
+		customEventRecorder->Send("c3d.SceneLoad", properties);
 	}
+
+	//will send events to the unloaded level before changing tracking scene id
+	//this is done instead of a full flush of all streams so that dynamics from the loaded scene are not written to the unloaded level data
+	customEventRecorder->SendData(true);
 
 	if (data.IsValid())
 	{

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/DynamicObject.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/DynamicObject.cpp
@@ -677,8 +677,6 @@ void UDynamicObject::EndPlay(const EEndPlayReason::Type EndPlayReason)
 		break;
 	}
 
-	GLog->Log(" UDynamicObject::EndPlay " + MeshName);
-
 	if (!shouldWriteEndSnapshot) { return; }
 	CleanupDynamicObject();
 }
@@ -710,7 +708,6 @@ void UDynamicObject::CleanupDynamicObject()
 	//allow reusing generated dynamic ids (controllers, transient objects for SE only)
 	if (IdSourceType == EIdSourceType::GeneratedId)
 	{
-		GLog->Log(" UDynamicObject::CleanupDynamicObject marking objectid as unused for mesh " + MeshName);
 		ObjectID->Used = false;
 		dynamicObjectManager->UnregisterId(ObjectID->Id);
 	}

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/DynamicObjectManager.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/DynamicObjectManager.cpp
@@ -95,7 +95,10 @@ void FDynamicObjectManager::RegisterObjectId(FString MeshName, FString Id, FStri
 		auto level = GWorld->GetCurrentLevel();
 		FString levelName = level->GetFullGroupName(true);
 		TSharedPtr<FSceneData> data = cogProvider->GetSceneData(levelName);
-		entry.SetProperty("SceneID", data->Id);
+		if (data != nullptr)
+		{
+			entry.SetProperty("SceneID", data->Id);
+		}
 	}
 	manifest.Add(entry);
 	newManifest.Add(entry);

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/DynamicObjectManager.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/DynamicObjectManager.cpp
@@ -67,30 +67,25 @@ void FDynamicObjectManager::UnregisterId(const FString id)
 {
 	for (int32 i = 0; i < allObjectIds.Num(); i++)
 	{
-		if (allObjectIds[i].IsValid() == false) { GLog->Log("invalid"); continue; }
-		if (allObjectIds[i]->Id != id) { GLog->Log("id mismatch"); continue; }
+		if (allObjectIds[i].IsValid() == false) { continue; }
+		if (allObjectIds[i]->Id != id) { continue; }
 
 		allObjectIds[i]->Used = false;
-		GLog->Log(" FDynamicObjectManager::GetUniqueObjectId freed ObjectId for id " + id);
 		break;
 	}
 }
 
 TSharedPtr<FDynamicObjectId> FDynamicObjectManager::GetUniqueObjectId(const FString meshName)
 {
-	GLog->Log(" FDynamicObjectManager::GetUniqueObjectId looking through this many items " + FString::FromInt(allObjectIds.Num()));
-
 	//ObjectId from DynamicObject and ObjectId in allObjectIds aren't pointing to the same object
-
 	//look for an unused dynamic object id instance
 	for (int32 i = 0; i < allObjectIds.Num(); i++)
 	{
-		if (allObjectIds[i].IsValid() == false) { GLog->Log("invalid"); continue; }
-		if (allObjectIds[i]->Used == true) { GLog->Log("still used"); continue; }
-		if (allObjectIds[i]->MeshName != meshName) { GLog->Log("mesh name mismatch" + allObjectIds[i]->MeshName + "     " + meshName); continue; }
+		if (allObjectIds[i].IsValid() == false) { continue; }
+		if (allObjectIds[i]->Used == true) { continue; }
+		if (allObjectIds[i]->MeshName != meshName) { continue; }
 
 		allObjectIds[i]->Used = true;
-		GLog->Log(" FDynamicObjectManager::GetUniqueObjectId recycling ObjectId for mesh " + meshName);
 		return allObjectIds[i];
 	}
 
@@ -99,7 +94,6 @@ TSharedPtr<FDynamicObjectId> FDynamicObjectManager::GetUniqueObjectId(const FStr
 	static int32 originalId = 1000;
 	originalId++;
 	freeId = MakeShareable(new FDynamicObjectId(FString::FromInt(originalId), meshName));
-	GLog->Log(" FDynamicObjectManager::GetUniqueObjectId creating new ObjectId for mesh " + meshName);
 	return freeId;
 }
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/DynamicObjectManager.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/DynamicObjectManager.cpp
@@ -128,7 +128,7 @@ void FDynamicObjectManager::RegisterObjectId(FString MeshName, FString Id, FStri
 	}
 
 	//check if object with Id already existst in allObjectIds. if so, don't add it to the list again
-	bool containsId;
+	bool containsId = false;
 	for (int32 i = 0; i < allObjectIds.Num(); i++)
 	{
 		if (allObjectIds[i]->Id == Id)

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/DynamicObjectManager.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/DynamicObjectManager.cpp
@@ -92,6 +92,10 @@ void FDynamicObjectManager::RegisterObjectId(FString MeshName, FString Id, FStri
 	{
 		entry.ControllerType = ControllerType;
 		entry.IsRight = IsRightController;
+		auto level = GWorld->GetCurrentLevel();
+		FString levelName = level->GetFullGroupName(true);
+		TSharedPtr<FSceneData> data = cogProvider->GetSceneData(levelName);
+		entry.SetProperty("SceneID", data->Id);
 	}
 	manifest.Add(entry);
 	newManifest.Add(entry);
@@ -294,6 +298,11 @@ void FDynamicObjectManager::SendData(bool copyDataToCache)
 	cogProvider->network->NetworkCall("dynamics", OutputString, copyDataToCache);
 
 	snapshots.Empty();
+}
+
+TArray<FDynamicObjectManifestEntry> FDynamicObjectManager::GetDynamicsManifest()
+{
+	return manifest;
 }
 
 TSharedPtr<FJsonObject> FDynamicObjectManager::DynamicObjectManifestToString()

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/EyeCapture.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/EyeCapture.h
@@ -4,9 +4,6 @@
 
 #pragma once
 #include "CoreMinimal.h"
-#include "Cognitive3D/Public/DynamicObject.h"
-
-class UDynamicObject;
 
 //a collection of these are kept to record current and recent gaze data and the state of the eye
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/Cognitive3DBlueprints.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/Cognitive3DBlueprints.h
@@ -9,7 +9,6 @@
 #include "Cognitive3D/Public/Cognitive3DProvider.h"
 #include "AnalyticsBlueprintLibrary.h"
 #include "Runtime/Analytics/Analytics/Public/AnalyticsEventAttribute.h"
-#include "Cognitive3D/Public/DynamicObject.h"
 #include "Cognitive3D/Private/C3DComponents/PlayerTracker.h"
 #include "Cognitive3D/Private/ExitPoll.h"
 #include "Cognitive3D/Private/C3DComponents/FixationRecorder.h"
@@ -18,6 +17,7 @@
 #include "Cognitive3DBlueprints.generated.h"
 
 class Cognitive3DResponse;
+class UDynamicObject;
 
 UCLASS()
 class COGNITIVE3D_API UCognitive3DBlueprints : public UBlueprintFunctionLibrary

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/DynamicObject.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/DynamicObject.h
@@ -41,6 +41,7 @@ class COGNITIVE3D_API UDynamicObject : public USceneComponent
 
 private:
 
+	TSharedPtr<FAnalyticsProviderCognitive3D> cogProvider;
 	FDynamicObjectManager* dynamicObjectManager;
 	float currentTime = 0;
 	TSharedPtr<FDynamicObjectId> ObjectID;

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/DynamicObjectManager.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/DynamicObjectManager.h
@@ -55,7 +55,7 @@ public:
 	void CacheControllerPointer(UDynamicObject* object, bool isRight);
 	UFUNCTION()
 	void SendData(bool copyDataToCache);
-
+	TArray<FDynamicObjectManifestEntry> GetDynamicsManifest();
 private:
 	TArray<TSharedPtr<FJsonValueObject>> DynamicSnapshotsToString();
 	TSharedPtr<FJsonObject> DynamicObjectManifestToString();

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/DynamicObjectManager.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/DynamicObjectManager.h
@@ -15,10 +15,10 @@
 #include "Cognitive3D/Public/CustomEvent.h"
 #include "Cognitive3D/Public/DynamicIdPoolAsset.h"
 #include "MotionControllerComponent.h"
-#include "Cognitive3D/Public/DynamicObject.h"
 
 class UCustomEvent;
 class UCognitive3DBlueprints;
+class UDynamicObject;
 
 class COGNITIVE3D_API FDynamicObjectManager
 {
@@ -56,6 +56,10 @@ public:
 	UFUNCTION()
 	void SendData(bool copyDataToCache);
 	TArray<FDynamicObjectManifestEntry> GetDynamicsManifest();
+
+	///returns a DynamicObjectId instance. Generates a new instance (can reuse an unused instance if id source is generated)
+	TSharedPtr<FDynamicObjectId> GetUniqueObjectId(const FString meshName);
+	void UnregisterId(const FString id);
 private:
 	TArray<TSharedPtr<FJsonValueObject>> DynamicSnapshotsToString();
 	TSharedPtr<FJsonObject> DynamicObjectManifestToString();

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/DynamicComponentDetails.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/DynamicComponentDetails.cpp
@@ -132,9 +132,9 @@ bool IDynamicObjectComponentDetails::HasOwner() const
 
 bool IDynamicObjectComponentDetails::HasOwnerAndExportDirAndName() const
 {
-	if (!HasOwner()) { UE_LOG(LogTemp, Warning, TEXT("NO OWNER FOUND!")); return false; }
-	if (FCognitiveEditorTools::GetInstance()->GetBaseExportDirectory().IsEmpty()) { UE_LOG(LogTemp, Warning, TEXT("NO EXPORT DIRECTORY FOUND!")); return false; }
-	if (SelectedDynamicObject.Get()->MeshName.IsEmpty()) { UE_LOG(LogTemp, Warning, TEXT("NO MESH NAME FOUND!")); return false; }
+	if (!HasOwner()) { return false; }
+	if (FCognitiveEditorTools::GetInstance()->GetBaseExportDirectory().IsEmpty()) { return false; }
+	if (SelectedDynamicObject.Get()->MeshName.IsEmpty()) { return false; }
 	return true;
 }
 


### PR DESCRIPTION
# Description

Fixed issues related to dynamics, in situations where there are multiple tracked scenes, where the data manifest was being written to the json of the wrong level, causing issues where dynamics would be duplicated or not appear correctly. Also fixed the issue where controllers would be re-generated each time a level is loaded, due to the nature of VR_Pawn spawning on level load, causing the controllers to have multiple manifest entries with different IDs each time, which was causing problems on the backend. Now should check if that level has controller IDs generated already and re-assign them back to the controllers when they re-enter the level.
Fixed incorrect custom event position.

Height Task ID(s) (If applicable): T-7590, T-7716, T-7783

## Type of change

> Note: delete the lines that are not applicable and check the boxes (add a capital "X" in the square brackets) for the type of change.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
