### PR TITLE
gltfexporter code, compression for large textures, export path fix

### DIFF
--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Cognitive3DEditor.Build.cs
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Cognitive3DEditor.Build.cs
@@ -62,7 +62,8 @@ public class Cognitive3DEditor : ModuleRules
                 "PluginBrowser",
                 "Projects",
                 "Cognitive3D",
-				"RenderCore"
+				"RenderCore",
+                "GLTFExporter"
             }
 		);
 		PrivateIncludePathModuleNames.AddRange(

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
@@ -2918,10 +2918,11 @@ void FCognitiveEditorTools::ExportScene(TArray<AActor*> actorsToExport)
 	ExportTask->Exporter->RunAssetExportTask(ExportTask);
 
 	// Compress and save textures after export
-	int32 MaxSize = 1024; // Adjust the size as needed
-
-	CompressTexturesInExportFolder(FCognitiveEditorTools::GetInstance()->GetCurrentSceneExportDirectory(), MaxSize);
-	
+	if (CompressExportedFiles)
+	{
+		int32 MaxSize = 1024; // Adjust the size as needed
+		CompressTexturesInExportFolder(FCognitiveEditorTools::GetInstance()->GetCurrentSceneExportDirectory(), MaxSize);
+	}
 
 	//check that the map was actually exported and generated temporary files
 	IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
@@ -1692,6 +1692,7 @@ void FCognitiveEditorTools::UploadFromDirectory(FString url, FString directory, 
 		}
 		else
 		{
+			AllBytes.Append(contentArray[i].BodyBinary);
 		}
 	}
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.h
@@ -14,6 +14,13 @@
 #include "Json.h"
 #include "JsonObjectConverter.h"
 #include "UnrealEd.h"
+#include "GLTFExportOptions.h"
+#include "GLTFExporter.h"
+#include "Exporters/GLTFLevelExporter.h" 
+#include "AssetExportTask.h"
+#include "Engine/Texture.h"
+#include "Engine/Texture2D.h"
+#include "ImageUtils.h"
 #include "Misc/FileHelper.h"
 #include "Misc/ScopedSlowTask.h"
 #include "Misc/LocalTimestampDirectoryVisitor.h"
@@ -49,7 +56,6 @@
 #include "Widgets/Notifications/SNotificationList.h"
 
 //all sorts of functionality for Cognitive SDK
-
 
 class FCognitiveEditorTools
 {
@@ -169,6 +175,9 @@ public:
 
 	TArray<AActor*> PrepareSceneForExport(bool OnlyExportSelected);
 	
+	void CompressTexturesInExportFolder(const FString& ExportFolder, int32 MaxSize);
+	void CompressAndSaveTexture(const FString& SourcePath, const FString& DestinationPath, int32 MaxSize);
+
 	void UploadFromDirectory(FString url, FString directory, FString expectedResponseType);
 
 	//dynamic objects

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.h
@@ -175,6 +175,7 @@ public:
 
 	TArray<AActor*> PrepareSceneForExport(bool OnlyExportSelected);
 	
+	bool CompressExportedFiles = false;
 	void CompressTexturesInExportFolder(const FString& ExportFolder, int32 MaxSize);
 	void CompressAndSaveTexture(const FString& SourcePath, const FString& DestinationPath, int32 MaxSize);
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
@@ -1465,7 +1465,25 @@ EVisibility SSceneSetupWidget::UploadErrorVisibility() const
 {
 	if (FCognitiveEditorTools::GetInstance()->WizardUploadResponseCode == 200) { return EVisibility::Collapsed; }
 	if (FCognitiveEditorTools::GetInstance()->WizardUploadResponseCode == 201) { return EVisibility::Collapsed; }
-	return FCognitiveEditorTools::GetInstance()->WizardUploadError.Len() == 0 ? EVisibility::Collapsed : EVisibility::Visible;
+	if (FCognitiveEditorTools::GetInstance()->WizardUploadError.Len() > 0)
+	{
+		if (FCognitiveEditorTools::GetInstance()->WizardUploadError.Contains("OnUploadObjectCompleted"))
+		{
+			if (FCognitiveEditorTools::GetInstance()->HasExportedAnyDynamicMeshes())
+			{
+				return EVisibility::Visible;
+			}
+			else
+			{
+				return EVisibility::Collapsed;
+			}
+		}
+		else
+		{
+			return EVisibility::Visible;
+		}
+	}
+	return EVisibility::Collapsed;
 }
 
 FText SSceneSetupWidget::UploadErrorText() const
@@ -1512,7 +1530,9 @@ void SSceneSetupWidget::OnExportPathChanged(const FText& Text)
 	if (Text.IsEmpty())
 	{
 		FCognitiveEditorTools::GetInstance()->SetDefaultIfNoExportDirectory();
+		FCognitiveEditorTools::GetInstance()->RefreshSceneUploadFiles();
 	}
+	FCognitiveEditorTools::GetInstance()->RefreshSceneUploadFiles();
 }
 
 void SSceneSetupWidget::SpawnCognitive3DActor()

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
@@ -471,6 +471,31 @@ void SSceneSetupWidget::Construct(const FArguments& Args)
 			]
 
 			+ SVerticalBox::Slot()
+			.HAlign(HAlign_Center)
+			.AutoHeight()
+			.Padding(0, 0, 0, padding)
+			[
+				SNew(SHorizontalBox)
+				.Visibility(this, &SSceneSetupWidget::IsExportVisible)
+				+ SHorizontalBox::Slot()
+				.AutoWidth()
+				.HAlign(HAlign_Left)
+				[
+					SNew(SCheckBox) ////
+					.Visibility(this, &SSceneSetupWidget::IsExportVisible)
+				.IsChecked(this, &SSceneSetupWidget::GetCompressFilesCheckbox)
+				.OnCheckStateChanged(this, &SSceneSetupWidget::OnChangeCompressFilesCheckbox)
+				]
+				+ SHorizontalBox::Slot()
+				.HAlign(HAlign_Left)
+				[
+					SNew(STextBlock)
+					.Visibility(this, &SSceneSetupWidget::IsExportVisible)
+				.Text(FText::FromString("Compress exported files. Note: this will not affect project files. Recommended for very large and detailed scenes."))
+				]
+			]
+
+			+ SVerticalBox::Slot()
 			.Padding(0, 0, 0, padding)
 			.HAlign(EHorizontalAlignment::HAlign_Center)
 			.MaxHeight(40)
@@ -984,6 +1009,12 @@ FReply SSceneSetupWidget::SelectAll()
 ECheckBoxState SSceneSetupWidget::GetOnlyExportSelectedCheckbox() const
 {
 	if (OnlyExportSelected)return ECheckBoxState::Checked;
+	return ECheckBoxState::Unchecked;
+}
+
+ECheckBoxState SSceneSetupWidget::GetCompressFilesCheckbox() const
+{
+	if (FCognitiveEditorTools::GetInstance()->CompressExportedFiles)return ECheckBoxState::Checked;
 	return ECheckBoxState::Unchecked;
 }
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.h
@@ -147,6 +147,19 @@ public:
 		}
 	}
 
+	ECheckBoxState GetCompressFilesCheckbox() const;
+	void OnChangeCompressFilesCheckbox(ECheckBoxState newstate)
+	{
+		if (newstate == ECheckBoxState::Checked)
+		{
+			FCognitiveEditorTools::GetInstance()->CompressExportedFiles = true;
+		}
+		else
+		{
+			FCognitiveEditorTools::GetInstance()->CompressExportedFiles = false;
+		}
+	}
+
 	void OnExportPathChanged(const FText& Text);
 
 	/// <summary>


### PR DESCRIPTION
# Description

Use GLTFExporter in code to remove friction related to the export process. This allows us to set things like scale to avoid developer mistakes. Also includes compression for very large textures to cap them at a set size. Fixed saving exported files to export directories with spaces in them.

Height Task ID(s) (If applicable): T-7832, T-7206, T-4557

## Type of change

> Note: delete the lines that are not applicable and check the boxes (add a capital "X" in the square brackets) for the type of change.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
