### PR TITLE
checkbox to export dynamics alongside scene geometry

### DIFF
--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
@@ -1596,6 +1596,61 @@ int32 FCognitiveEditorTools::GetDynamicObjectExportedCount()
 	return folders.Num();
 }
 
+int32 FCognitiveEditorTools::CountUnexportedDynamics()
+{
+	UWorld* tempworld = GEditor->GetEditorWorldContext().World();
+
+	if (!tempworld)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorToolsCustomization::ExportDynamics world is null"));
+		return -1;
+	}
+
+	if (BaseExportDirectory.Len() == 0)
+	{
+		GLog->Log("base directory not selected");
+		return -1;
+	}
+
+	TArray<FString> meshNames;
+	TArray<UDynamicObject*> exportObjects;
+
+	//get all dynamic object components in scene. add names/pointers to array
+	for (TActorIterator<AActor> ActorItr(GWorld); ActorItr; ++ActorItr)
+	{
+		for (UActorComponent* actorComponent : ActorItr->GetComponents())
+		{
+			if (actorComponent->IsA(UDynamicObject::StaticClass()))
+			{
+				UDynamicObject* dynamicComponent = Cast<UDynamicObject>(actorComponent);
+				if (dynamicComponent == NULL)
+				{
+					continue;
+				}
+				FString path = GetDynamicsExportDirectory() + "/" + dynamicComponent->MeshName + "/" + dynamicComponent->MeshName;
+				FString gltfpath = path + ".gltf";
+				if (FPaths::FileExists(*gltfpath))
+				{
+					//already exported
+					continue;
+				}
+				if (!meshNames.Contains(dynamicComponent->MeshName))
+				{
+					exportObjects.Add(dynamicComponent);
+					meshNames.Add(dynamicComponent->MeshName);
+				}
+			}
+		}
+	}
+
+	if (meshNames.Num() == 0)
+	{
+		return 0;
+	}
+
+	return meshNames.Num();
+}
+
 void FCognitiveEditorTools::UploadFromDirectory(FString url, FString directory, FString expectedResponseType)
 {
 	FString filesStartingWith = TEXT("");

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
@@ -2939,6 +2939,12 @@ void FCognitiveEditorTools::ExportScene(TArray<AActor*> actorsToExport)
 		CompressTexturesInExportFolder(FCognitiveEditorTools::GetInstance()->GetCurrentSceneExportDirectory(), MaxSize);
 	}
 
+	if (ExportDynamicsWithScene)
+	{
+		//ExportNewDynamics(); //maybe this for unexported dynamics? use its logic to count unexported dynamics?
+		ExportAllDynamics();
+	}
+
 	//check that the map was actually exported and generated temporary files
 	IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
 	if (!PlatformFile.FileExists(*ExportedSceneFile2))

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.h
@@ -179,6 +179,8 @@ public:
 	void CompressTexturesInExportFolder(const FString& ExportFolder, int32 MaxSize);
 	void CompressAndSaveTexture(const FString& SourcePath, const FString& DestinationPath, int32 MaxSize);
 
+	bool ExportDynamicsWithScene = false;
+
 	void UploadFromDirectory(FString url, FString directory, FString expectedResponseType);
 
 	//dynamic objects

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.h
@@ -180,6 +180,7 @@ public:
 	void CompressAndSaveTexture(const FString& SourcePath, const FString& DestinationPath, int32 MaxSize);
 
 	bool ExportDynamicsWithScene = false;
+	int32 CountUnexportedDynamics();
 
 	void UploadFromDirectory(FString url, FString directory, FString expectedResponseType);
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
@@ -507,16 +507,16 @@ void SSceneSetupWidget::Construct(const FArguments& Args)
 				.HAlign(HAlign_Left)
 				[
 					SNew(SCheckBox) ////
-					.Visibility(this, &SSceneSetupWidget::IsExportVisible)
-				.IsChecked(this, &SSceneSetupWidget::GetExportDynamicsCheckbox)
-				.OnCheckStateChanged(this, &SSceneSetupWidget::OnChangeExportDynamicsCheckbox)
+					.Visibility(this, &SSceneSetupWidget::IsExportDynamicsVisible)
+					.IsChecked(this, &SSceneSetupWidget::GetExportDynamicsCheckbox)
+					.OnCheckStateChanged(this, &SSceneSetupWidget::OnChangeExportDynamicsCheckbox)
 				]
-				+ SHorizontalBox::Slot()
-				.HAlign(HAlign_Left)
+					+ SHorizontalBox::Slot()
+					.HAlign(HAlign_Left)
 				[
 					SNew(STextBlock)
-					.Visibility(this, &SSceneSetupWidget::IsExportVisible)
-				.Text(FText::FromString("Export Dynamic Objects alongside Scene Geometry."))
+					.Visibility(this, &SSceneSetupWidget::IsExportDynamicsVisible)
+					.Text(this, &SSceneSetupWidget::ExportDynamicsText)
 				]
 			]
 
@@ -1137,6 +1137,10 @@ EVisibility SSceneSetupWidget::IsUploadChecklistVisible() const
 {
 	return CurrentPageEnum == ESceneSetupPage::UploadChecklist ? EVisibility::Visible : EVisibility::Collapsed;
 }
+EVisibility SSceneSetupWidget::IsExportDynamicsVisible() const
+{
+	return FCognitiveEditorTools::GetInstance()->CountUnexportedDynamics() > 0 ? EVisibility::Visible : EVisibility::Collapsed;
+}
 EVisibility SSceneSetupWidget::IsCompleteVisible() const
 {
 	return CurrentPageEnum == ESceneSetupPage::Complete ? EVisibility::Visible : EVisibility::Collapsed;
@@ -1187,6 +1191,12 @@ FText SSceneSetupWidget::ExportButtonText()const
 		return FText::FromString(TEXT("Export All"));
 	}
 	return FText::FromString(TEXT("Export All"));
+}
+
+FText SSceneSetupWidget::ExportDynamicsText() const
+{
+	FString DynamicsText = FString::Printf(TEXT("Export %d unexported dynamics alongside the scene geometry"), FCognitiveEditorTools::GetInstance()->CountUnexportedDynamics());
+	return FText::FromString(DynamicsText);
 }
 
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
@@ -481,7 +481,7 @@ void SSceneSetupWidget::Construct(const FArguments& Args)
 				.AutoWidth()
 				.HAlign(HAlign_Left)
 				[
-					SNew(SCheckBox) ////
+					SNew(SCheckBox)
 					.Visibility(this, &SSceneSetupWidget::IsExportVisible)
 				.IsChecked(this, &SSceneSetupWidget::GetCompressFilesCheckbox)
 				.OnCheckStateChanged(this, &SSceneSetupWidget::OnChangeCompressFilesCheckbox)
@@ -495,18 +495,35 @@ void SSceneSetupWidget::Construct(const FArguments& Args)
 				]
 			]
 
-			+ SVerticalBox::Slot() ////
+			+ SVerticalBox::Slot()
 			.HAlign(HAlign_Center)
 			.AutoHeight()
 			.Padding(0, 0, 0, padding)
 			[
 				SNew(SHorizontalBox)
 				.Visibility(this, &SSceneSetupWidget::IsExportVisible)
+				+SHorizontalBox::Slot()
+				.HAlign(HAlign_Left)
+				[
+					SNew(STextBlock)
+					.Visibility(this, &SSceneSetupWidget::IsExportVisible)
+					.Text(this, &SSceneSetupWidget::DynamicsStatusTest)
+				]
+			]
+
+			+ SVerticalBox::Slot()
+			.HAlign(HAlign_Center)
+			.AutoHeight()
+			.Padding(0, 0, 0, padding)
+			[
+				SNew(SHorizontalBox)
+				.Visibility(this, &SSceneSetupWidget::IsExportVisible)
+				
 				+ SHorizontalBox::Slot()
 				.AutoWidth()
 				.HAlign(HAlign_Left)
 				[
-					SNew(SCheckBox) ////
+					SNew(SCheckBox)
 					.Visibility(this, &SSceneSetupWidget::IsExportDynamicsVisible)
 					.IsChecked(this, &SSceneSetupWidget::GetExportDynamicsCheckbox)
 					.OnCheckStateChanged(this, &SSceneSetupWidget::OnChangeExportDynamicsCheckbox)
@@ -1193,9 +1210,15 @@ FText SSceneSetupWidget::ExportButtonText()const
 	return FText::FromString(TEXT("Export All"));
 }
 
+FText SSceneSetupWidget::DynamicsStatusTest() const
+{
+	FString DynamicsText = FString::Printf(TEXT("%d out of %d dynamic objects in this scene have been exported."), FCognitiveEditorTools::GetInstance()->CountDynamicObjectsInScene() - FCognitiveEditorTools::GetInstance()->CountUnexportedDynamics(), FCognitiveEditorTools::GetInstance()->CountDynamicObjectsInScene());
+	return FText::FromString(DynamicsText);
+}
+
 FText SSceneSetupWidget::ExportDynamicsText() const
 {
-	FString DynamicsText = FString::Printf(TEXT("Export %d unexported dynamics alongside the scene geometry"), FCognitiveEditorTools::GetInstance()->CountUnexportedDynamics());
+	FString DynamicsText = FString::Printf(TEXT("Export %d un-exported dynamic objects alongside the scene geometry."), FCognitiveEditorTools::GetInstance()->CountUnexportedDynamics());
 	return FText::FromString(DynamicsText);
 }
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
@@ -495,6 +495,31 @@ void SSceneSetupWidget::Construct(const FArguments& Args)
 				]
 			]
 
+			+ SVerticalBox::Slot() ////
+			.HAlign(HAlign_Center)
+			.AutoHeight()
+			.Padding(0, 0, 0, padding)
+			[
+				SNew(SHorizontalBox)
+				.Visibility(this, &SSceneSetupWidget::IsExportVisible)
+				+ SHorizontalBox::Slot()
+				.AutoWidth()
+				.HAlign(HAlign_Left)
+				[
+					SNew(SCheckBox) ////
+					.Visibility(this, &SSceneSetupWidget::IsExportVisible)
+				.IsChecked(this, &SSceneSetupWidget::GetExportDynamicsCheckbox)
+				.OnCheckStateChanged(this, &SSceneSetupWidget::OnChangeExportDynamicsCheckbox)
+				]
+				+ SHorizontalBox::Slot()
+				.HAlign(HAlign_Left)
+				[
+					SNew(STextBlock)
+					.Visibility(this, &SSceneSetupWidget::IsExportVisible)
+				.Text(FText::FromString("Export Dynamic Objects alongside Scene Geometry."))
+				]
+			]
+
 			+ SVerticalBox::Slot()
 			.Padding(0, 0, 0, padding)
 			.HAlign(EHorizontalAlignment::HAlign_Center)
@@ -1015,6 +1040,12 @@ ECheckBoxState SSceneSetupWidget::GetOnlyExportSelectedCheckbox() const
 ECheckBoxState SSceneSetupWidget::GetCompressFilesCheckbox() const
 {
 	if (FCognitiveEditorTools::GetInstance()->CompressExportedFiles)return ECheckBoxState::Checked;
+	return ECheckBoxState::Unchecked;
+}
+
+ECheckBoxState SSceneSetupWidget::GetExportDynamicsCheckbox() const
+{
+	if (FCognitiveEditorTools::GetInstance()->ExportDynamicsWithScene)return ECheckBoxState::Checked;
 	return ECheckBoxState::Unchecked;
 }
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.h
@@ -160,6 +160,19 @@ public:
 		}
 	}
 
+	ECheckBoxState GetExportDynamicsCheckbox() const;
+	void OnChangeExportDynamicsCheckbox(ECheckBoxState newstate)
+	{
+		if (newstate == ECheckBoxState::Checked)
+		{
+			FCognitiveEditorTools::GetInstance()->ExportDynamicsWithScene = true;
+		}
+		else
+		{
+			FCognitiveEditorTools::GetInstance()->ExportDynamicsWithScene = false;
+		}
+	}
+
 	void OnExportPathChanged(const FText& Text);
 
 	/// <summary>

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.h
@@ -86,6 +86,7 @@ public:
 	EVisibility IsControllerVisible() const;
 	EVisibility IsExportVisible() const;
 	EVisibility IsUploadChecklistVisible() const;
+	EVisibility IsExportDynamicsVisible() const;
 	EVisibility IsUploadProgressVisible() const;
 	EVisibility IsCompleteVisible() const;
 	EVisibility IsUploadComplete() const;
@@ -94,6 +95,7 @@ public:
 	EVisibility IsNotOnlyExportSelected() const;
 
 	FText ExportButtonText() const;
+	FText ExportDynamicsText() const;
 
 	EVisibility IsNewSceneUpload() const;
 	EVisibility IsSceneVersionUpload() const;

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.h
@@ -95,6 +95,7 @@ public:
 	EVisibility IsNotOnlyExportSelected() const;
 
 	FText ExportButtonText() const;
+	FText DynamicsStatusTest() const;
 	FText ExportDynamicsText() const;
 
 	EVisibility IsNewSceneUpload() const;


### PR DESCRIPTION
# Description

Added a checkbox to the export screen that allows the user to export dynamics in the scene while also exporting the scene geometry. This is to reduce workflow needed when they want to upload all dynamics without being specific, which that remains the function of the dynamics manager page.

Height Task ID(s) (If applicable): T-8105

## Type of change

> Note: delete the lines that are not applicable and check the boxes (add a capital "X" in the square brackets) for the type of change.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
