### PR TITLE
add function to check non-unique dynamics, updated ux

### DIFF
--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
@@ -1651,6 +1651,61 @@ int32 FCognitiveEditorTools::CountUnexportedDynamics()
 	return meshNames.Num();
 }
 
+int32 FCognitiveEditorTools::CountUnexportedDynamicsNotUnique()
+{
+	UWorld* tempworld = GEditor->GetEditorWorldContext().World();
+
+	if (!tempworld)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorToolsCustomization::ExportDynamics world is null"));
+		return -1;
+	}
+
+	if (BaseExportDirectory.Len() == 0)
+	{
+		GLog->Log("base directory not selected");
+		return -1;
+	}
+
+	TArray<FString> meshNames;
+	TArray<UDynamicObject*> exportObjects;
+
+	//get all dynamic object components in scene. add names/pointers to array
+	for (TActorIterator<AActor> ActorItr(GWorld); ActorItr; ++ActorItr)
+	{
+		for (UActorComponent* actorComponent : ActorItr->GetComponents())
+		{
+			if (actorComponent->IsA(UDynamicObject::StaticClass()))
+			{
+				UDynamicObject* dynamicComponent = Cast<UDynamicObject>(actorComponent);
+				if (dynamicComponent == NULL)
+				{
+					continue;
+				}
+				FString path = GetDynamicsExportDirectory() + "/" + dynamicComponent->MeshName + "/" + dynamicComponent->MeshName;
+				FString gltfpath = path + ".gltf";
+				if (FPaths::FileExists(*gltfpath))
+				{
+					//already exported
+					continue;
+				}
+				else 
+				{
+					exportObjects.Add(dynamicComponent);
+					meshNames.Add(dynamicComponent->MeshName);
+				}
+			}
+		}
+	}
+
+	if (meshNames.Num() == 0)
+	{
+		return 0;
+	}
+
+	return meshNames.Num();
+}
+
 void FCognitiveEditorTools::UploadFromDirectory(FString url, FString directory, FString expectedResponseType)
 {
 	FString filesStartingWith = TEXT("");

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.h
@@ -181,6 +181,7 @@ public:
 
 	bool ExportDynamicsWithScene = false;
 	int32 CountUnexportedDynamics();
+	int32 CountUnexportedDynamicsNotUnique();
 
 	void UploadFromDirectory(FString url, FString directory, FString expectedResponseType);
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
@@ -1216,13 +1216,13 @@ FText SSceneSetupWidget::ExportButtonText()const
 
 FText SSceneSetupWidget::DynamicsStatusTest() const
 {
-	FString DynamicsText = FString::Printf(TEXT("%d out of %d dynamic objects in this scene have been exported."), FCognitiveEditorTools::GetInstance()->CountDynamicObjectsInScene() - FCognitiveEditorTools::GetInstance()->CountUnexportedDynamics(), FCognitiveEditorTools::GetInstance()->CountDynamicObjectsInScene());
+	FString DynamicsText = FString::Printf(TEXT("%d out of %d dynamic objects in this scene have been exported."), FCognitiveEditorTools::GetInstance()->CountDynamicObjectsInScene() - FCognitiveEditorTools::GetInstance()->CountUnexportedDynamicsNotUnique(), FCognitiveEditorTools::GetInstance()->CountDynamicObjectsInScene());
 	return FText::FromString(DynamicsText);
 }
 
 FText SSceneSetupWidget::ExportDynamicsText() const
 {
-	FString DynamicsText = FString::Printf(TEXT("Export %d un-exported dynamic objects alongside the scene geometry."), FCognitiveEditorTools::GetInstance()->CountUnexportedDynamics());
+	FString DynamicsText = FString::Printf(TEXT("Export %d un-exported dynamic objects alongside the scene geometry."), FCognitiveEditorTools::GetInstance()->CountUnexportedDynamicsNotUnique());
 	return FText::FromString(DynamicsText);
 }
 


### PR DESCRIPTION
# Description

Adjusted UX showing number of unexported dynamics in the scene to count non-unique instances of that dynamic. The goal is to show the total number of dynamic objects in the scene that need to be exported, rather than the number of meshes. Makes it more intuitive to the developer.

Height Task ID(s) (If applicable): T-8822

## Type of change

> Note: delete the lines that are not applicable and check the boxes (add a capital "X" in the square brackets) for the type of change.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
