### PR TITLE
fixing missing OculusInput bug and engine requirement

### DIFF
--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Cognitive3D.Build.cs
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Cognitive3D.Build.cs
@@ -128,7 +128,7 @@ namespace UnrealBuildTool.Rules
 		void MetaXRPlugin()
         {
 			PublicDefinitions.Add("INCLUDE_OCULUS_PLUGIN");
-			PublicDependencyModuleNames.AddRange(new string[] { "OculusHMD" });
+			PublicDependencyModuleNames.AddRange(new string[] { "OculusHMD", "OculusInput" });
 		}
 
 		void MetaXRPassthrough()

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/EnhancedInputTracker.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/EnhancedInputTracker.h
@@ -11,7 +11,11 @@
 #include "InputModifiers.h"
 #include "InputTriggers.h"
 #ifdef INCLUDE_OCULUS_PLUGIN
+#if ENGINE_MAJOR_VERSION == 4 
+#include "OculusInputFunctionLibrary.h"
+#elif ENGINE_MAJOR_VERSION == 5 
 #include "OculusXRInputFunctionLibrary.h"
+#endif
 #endif
 #ifdef INCLUDE_PICO_PLUGIN
 #include "PXR_InputFunctionLibrary.h"

--- a/update5_0.py
+++ b/update5_0.py
@@ -125,7 +125,7 @@ print (version)
 replaceline(cwd+"/Plugins\Cognitive3D\Source\Cognitive3D\Cognitive3D.Build.cs","				|| Target.Platform == UnrealTargetPlatform.Win32","//				|| Target.Platform == UnrealTargetPlatform.Win32")
 
 #change definitions and oculus plugin include in build.cs
-replaceline(cwd+"/Plugins\Cognitive3D\Source\Cognitive3D\Cognitive3D.Build.cs","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusHMD\" });","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusXRHMD\" });")
+replaceline(cwd+"/Plugins\Cognitive3D\Source\Cognitive3D\Cognitive3D.Build.cs","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusHMD\", \"OculusInput\" });","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusXRHMD\", \"OculusXRInput\" });")
 
 # save to zip archive
 output_filename = cwd+"/C3D_Plugin"+version+"_ue"+engineversion+"_"+enginesubversion

--- a/update5_1.py
+++ b/update5_1.py
@@ -126,7 +126,7 @@ print (version)
 replaceline(cwd+"/Plugins\Cognitive3D\Source\Cognitive3D\Cognitive3D.Build.cs","				|| Target.Platform == UnrealTargetPlatform.Win32","//				|| Target.Platform == UnrealTargetPlatform.Win32")
 
 #change definitions and oculus plugin include in build.cs
-replaceline(cwd+"/Plugins\Cognitive3D\Source\Cognitive3D\Cognitive3D.Build.cs","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusHMD\" });","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusXRHMD\" });")
+replaceline(cwd+"/Plugins\Cognitive3D\Source\Cognitive3D\Cognitive3D.Build.cs","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusHMD\", \"OculusInput\" });","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusXRHMD\", \"OculusXRInput\" });")
 
 
 # save to zip archive

--- a/update5_2.py
+++ b/update5_2.py
@@ -126,7 +126,7 @@ print (version)
 replaceline(cwd+"/Plugins\Cognitive3D\Source\Cognitive3D\Cognitive3D.Build.cs","				|| Target.Platform == UnrealTargetPlatform.Win32","//				|| Target.Platform == UnrealTargetPlatform.Win32")
 
 #change definitions and oculus plugin include in build.cs
-replaceline(cwd+"/Plugins\Cognitive3D\Source\Cognitive3D\Cognitive3D.Build.cs","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusHMD\" });","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusXRHMD\" });")
+replaceline(cwd+"/Plugins\Cognitive3D\Source\Cognitive3D\Cognitive3D.Build.cs","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusHMD\", \"OculusInput\" });","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusXRHMD\", \"OculusXRInput\" });")
 
 # save to zip archive
 output_filename = cwd+"/C3D_Plugin"+version+"_ue"+engineversion+"_"+enginesubversion

--- a/update5_3.py
+++ b/update5_3.py
@@ -126,7 +126,7 @@ print (version)
 replaceline(cwd+"/Plugins\Cognitive3D\Source\Cognitive3D\Cognitive3D.Build.cs","				|| Target.Platform == UnrealTargetPlatform.Win32","//				|| Target.Platform == UnrealTargetPlatform.Win32")
 
 #change definitions and oculus plugin include in build.cs
-replaceline(cwd+"/Plugins\Cognitive3D\Source\Cognitive3D\Cognitive3D.Build.cs","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusHMD\" });","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusXRHMD\" });")
+replaceline(cwd+"/Plugins\Cognitive3D\Source\Cognitive3D\Cognitive3D.Build.cs","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusHMD\", \"OculusInput\" });","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusXRHMD\", \"OculusXRInput\" });")
 
 insertline(cwd+"/Plugins\Cognitive3D\Source\Cognitive3D\Cognitive3D.Build.cs","					\"Slate\",","					\"XRBase\",",)
 

--- a/update5_4.py
+++ b/update5_4.py
@@ -126,7 +126,7 @@ print (version)
 replaceline(cwd+"/Plugins\Cognitive3D\Source\Cognitive3D\Cognitive3D.Build.cs","				|| Target.Platform == UnrealTargetPlatform.Win32","//				|| Target.Platform == UnrealTargetPlatform.Win32")
 
 #change definitions and oculus plugin include in build.cs
-replaceline(cwd+"/Plugins\Cognitive3D\Source\Cognitive3D\Cognitive3D.Build.cs","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusHMD\" });","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusXRHMD\" });")
+replaceline(cwd+"/Plugins\Cognitive3D\Source\Cognitive3D\Cognitive3D.Build.cs","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusHMD\", \"OculusInput\" });","			PublicDependencyModuleNames.AddRange(new string[] { \"OculusXRHMD\", \"OculusXRInput\" });")
 
 insertline(cwd+"/Plugins\Cognitive3D\Source\Cognitive3D\Cognitive3D.Build.cs","					\"Slate\",","					\"XRBase\",",)
 


### PR DESCRIPTION
# Description

Quick fix for missing OculusInput definition and also engine specific includes for its libraries, changed python files to accommodate for it as well

Height Task ID(s) (If applicable): T-8947

## Type of change

> Note: delete the lines that are not applicable and check the boxes (add a capital "X" in the square brackets) for the type of change.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
