### PR TITLE
Dynamics improvements - mass assign dynamic objects

### DIFF
--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/DynamicObject.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/DynamicObject.cpp
@@ -136,34 +136,41 @@ void UDynamicObject::SetUniqueDynamicIds()
 //utility used in editor
 void UDynamicObject::TryGenerateMeshName()
 {
-	if (GetOwner() == NULL)
+	if (GetOwner() == NULL || GetAttachParent() == NULL)
 	{
 		return;
 	}
 
 	if (MeshName.IsEmpty())
 	{
-		UActorComponent* actorComponent = GetOwner()->GetComponentByClass(UStaticMeshComponent::StaticClass());
-		if (actorComponent != NULL)
+		if (GetAttachParent()->IsA<UStaticMeshComponent>())
 		{
-			UStaticMeshComponent* staticmeshComponent = Cast<UStaticMeshComponent>(actorComponent);
-			if (staticmeshComponent != NULL && staticmeshComponent->GetStaticMesh() != NULL)
+			USceneComponent* actorComponent = Cast<USceneComponent>(GetAttachParent());
+			if (actorComponent != NULL)
 			{
-				MeshName = staticmeshComponent->GetStaticMesh()->GetName();
-				return;
+				UStaticMeshComponent* staticmeshComponent = Cast<UStaticMeshComponent>(actorComponent);
+				if (staticmeshComponent != NULL && staticmeshComponent->GetStaticMesh() != NULL)
+				{
+					MeshName = staticmeshComponent->GetStaticMesh()->GetName();
+					return;
+				}
 			}
 		}
-
-		UActorComponent* actorSkeletalComponent = GetOwner()->GetComponentByClass(USkeletalMeshComponent::StaticClass());
-		if (actorSkeletalComponent != NULL)
+		
+		if (GetAttachParent()->IsA<USkeletalMeshComponent>())
 		{
-			USkeletalMeshComponent* skeletalmeshComponent = Cast<USkeletalMeshComponent>(actorSkeletalComponent);
-			if (skeletalmeshComponent != NULL && skeletalmeshComponent->SkeletalMesh != NULL)
+			USceneComponent* actorSkeletalComponent = Cast<USceneComponent>(GetAttachParent());
+			if (actorSkeletalComponent != NULL)
 			{
-				MeshName = skeletalmeshComponent->SkeletalMesh->GetName();
-				return;
+				USkeletalMeshComponent* skeletalmeshComponent = Cast<USkeletalMeshComponent>(actorSkeletalComponent);
+				if (skeletalmeshComponent != NULL && skeletalmeshComponent->SkeletalMesh != NULL)
+				{
+					MeshName = skeletalmeshComponent->SkeletalMesh->GetName();
+					return;
+				}
 			}
 		}
+		
 	}
 }
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
@@ -2185,36 +2185,40 @@ FReply FCognitiveEditorTools::RefreshDisplayDynamicObjectsCountInScene()
 		// Same as with the Object Iterator, access the subclass instance with the * or -> operators.
 		//AStaticMeshActor *Mesh = *ActorItr;
 
-		UActorComponent* actorComponent = (*ActorItr)->GetComponentByClass(UDynamicObject::StaticClass());
-		if (actorComponent == NULL)
-		{
-			continue;
-		}
-		UDynamicObject* dynamic = Cast<UDynamicObject>(actorComponent);
-		if (dynamic == NULL)
-		{
-			continue;
-		}
-		//populate id based on id type
-		if (dynamic->IdSourceType == EIdSourceType::CustomId)
-		{
-			SceneDynamics.Add(MakeShareable(new FDynamicData(dynamic->GetOwner()->GetName(), dynamic->MeshName, dynamic->CustomId, EDynamicTypes::CustomId)));
-		}
-		else if (dynamic->IdSourceType == EIdSourceType::GeneratedId)
-		{
-			FString idMessage = TEXT("Id generated during runtime");
-			//SceneDynamics.Add(MakeShareable(new FDynamicData(dynamic->GetOwner()->GetName(), dynamic->MeshName, *idMessage)));
-			SceneDynamics.Add(MakeShareable(new FDynamicData(dynamic->GetOwner()->GetName(), dynamic->MeshName, idMessage, EDynamicTypes::GeneratedId)));
-		}
-		else if (dynamic->IdSourceType == EIdSourceType::PoolId)
-		{
-			
-			//construct a string for the number of ids in the pool
-			FString IdString = FString::Printf(TEXT("Id Pool(%d)"), dynamic->IDPool->Ids.Num());
+		//try getting all components that are dynamic objects
+		TArray<UActorComponent*> actorComponents = (*ActorItr)->GetComponentsByClass(UDynamicObject::StaticClass());
 
-			//add it as TSharedPtr<FDynamicData> to the SceneDynamics
-			SceneDynamics.Add(MakeShareable(new FDynamicData(dynamic->GetOwner()->GetName(), dynamic->MeshName, IdString, dynamic->IDPool->Ids, EDynamicTypes::DynamicIdPool)));
+		for (UActorComponent* actorComp : actorComponents)
+		{
+			UDynamicObject* dynamic = Cast<UDynamicObject>(actorComp);
+			if (dynamic == NULL)
+			{
+				continue;
+			}
+
+			//populate id based on id type
+			if (dynamic->IdSourceType == EIdSourceType::CustomId)
+			{
+				SceneDynamics.Add(MakeShareable(new FDynamicData(dynamic->GetOwner()->GetName(), dynamic->MeshName, dynamic->CustomId, EDynamicTypes::CustomId)));
+			}
+			else if (dynamic->IdSourceType == EIdSourceType::GeneratedId)
+			{
+				FString idMessage = TEXT("Id generated during runtime");
+				//SceneDynamics.Add(MakeShareable(new FDynamicData(dynamic->GetOwner()->GetName(), dynamic->MeshName, *idMessage)));
+				SceneDynamics.Add(MakeShareable(new FDynamicData(dynamic->GetOwner()->GetName(), dynamic->MeshName, idMessage, EDynamicTypes::GeneratedId)));
+			}
+			else if (dynamic->IdSourceType == EIdSourceType::PoolId)
+			{
+
+				//construct a string for the number of ids in the pool
+				FString IdString = FString::Printf(TEXT("Id Pool(%d)"), dynamic->IDPool->Ids.Num());
+
+				//add it as TSharedPtr<FDynamicData> to the SceneDynamics
+				SceneDynamics.Add(MakeShareable(new FDynamicData(dynamic->GetOwner()->GetName(), dynamic->MeshName, IdString, dynamic->IDPool->Ids, EDynamicTypes::DynamicIdPool)));
+			}
+
 		}
+
 		//dynamics.Add(dynamic);
 	}
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/DynamicObjectManagerWidget.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/DynamicObjectManagerWidget.cpp
@@ -324,7 +324,7 @@ void SDynamicObjectManagerWidget::Construct(const FArguments& Args)
 						[
 							SNew(SButton)
 							.IsEnabled(this, &SDynamicObjectManagerWidget::IsActorInSceneSelected)
-							.Text(FText::FromString("Add Dynamic Object Components To Selected Actors in Scene"))
+							.Text(FText::FromString("Add Dynamic Object(s)"))
 							.ToolTipText(FText::FromString("Add Dynamic Object Components To Selected Actors in Scene"))
 							.OnClicked_Raw(this, &SDynamicObjectManagerWidget::AssignDynamicsToActors)
 						]
@@ -728,7 +728,7 @@ FReply SDynamicObjectManagerWidget::AssignDynamicsToActors()
 							Actor->AddInstanceComponent(NewComponent);
 							bAttachedToMeshComponent = true;
 							bActorHasDynamic = true;
-							break; // Exit the loop since we've attached our component
+							//break; // Exit the loop since we've attached our component
 						}
 					}
 				}

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/DynamicObjectManagerWidget.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/DynamicObjectManagerWidget.cpp
@@ -299,7 +299,17 @@ void SDynamicObjectManagerWidget::Construct(const FArguments& Args)
 				]
 			]
 
-			+ SVerticalBox::Slot() //upload buttons
+			+ SVerticalBox::Slot()
+				.AutoHeight()
+				.Padding(0, 0, 0, padding)
+				[
+					SNew(STextBlock)
+					.Justification(ETextJustify::Center)
+					.AutoWrapText(true)
+					.Text(FText::FromString("To easily assign Dynamic Objects to actors in your level, select them then press the button below."))
+				]
+
+			+ SVerticalBox::Slot() //upload buttons //
 				.Padding(0, 0, 0, padding)
 				.HAlign(EHorizontalAlignment::HAlign_Center)
 				.VAlign(VAlign_Center)
@@ -307,18 +317,18 @@ void SDynamicObjectManagerWidget::Construct(const FArguments& Args)
 				[
 					SNew(SHorizontalBox)
 					+ SHorizontalBox::Slot()
-				[
-					SNew(SBox)
-					.HeightOverride(32)
-				.WidthOverride(256)
-				[
-					SNew(SButton)
-					.IsEnabled(this, &SDynamicObjectManagerWidget::IsActorInSceneSelected)
-				.Text(FText::FromString("Add Dynamic Object Components To Selected Actors in Scene"))
-				.ToolTipText(FText::FromString("Add Dynamic Object Components To Selected Actors in Scene"))
-				.OnClicked_Raw(this, &SDynamicObjectManagerWidget::AssignDynamicsToActors)
-				]
-				]
+					[
+						SNew(SBox)
+						.HeightOverride(32)
+						.WidthOverride(256)
+						[
+							SNew(SButton)
+							.IsEnabled(this, &SDynamicObjectManagerWidget::IsActorInSceneSelected)
+							.Text(FText::FromString("Add Dynamic Object Components To Selected Actors in Scene"))
+							.ToolTipText(FText::FromString("Add Dynamic Object Components To Selected Actors in Scene"))
+							.OnClicked_Raw(this, &SDynamicObjectManagerWidget::AssignDynamicsToActors)
+						]
+					]
 			]
 
 			]
@@ -680,14 +690,60 @@ FReply SDynamicObjectManagerWidget::AssignDynamicsToActors()
 	{
 		if (AActor* Actor = Cast<AActor>(*It))
 		{
-			//add dynamic object to actor root
-			//Actor->AddComponentByClass(TSubclassOf<UDynamicObject>
-			// Attach a UDynamicObject component to the actor
-			UDynamicObject* NewComponent = NewObject<UDynamicObject>(Actor);
-			if (NewComponent)
+			bool bAttachedToMeshComponent = false;
+
+			// Get all components of the actor
+			TArray<UActorComponent*> Components;
+			Actor->GetComponents(Components);
+			bool bActorHasDynamic = false;
+			// Iterate over components to find mesh components
+			for (UActorComponent* Component : Components)
 			{
-				NewComponent->RegisterComponent(); // Make sure the component is registered
-				Actor->AddInstanceComponent(NewComponent); // Add it to the actor's components
+				UMeshComponent* MeshComponent = Cast<UMeshComponent>(Component);
+				if (MeshComponent)
+				{
+					// Get direct children of the mesh component
+					TArray<USceneComponent*> MeshChildren;
+					MeshComponent->GetChildrenComponents(false, MeshChildren);
+
+					bool bHasDynamicObjectChild = false;
+					for (USceneComponent* Child : MeshChildren)
+					{
+						if (Child && Child->IsA<UDynamicObject>())
+						{
+							bHasDynamicObjectChild = true;
+							bActorHasDynamic = true;
+							break;
+						}
+					}
+
+					if (!bHasDynamicObjectChild)
+					{
+						// Attach the DynamicObject to this mesh component
+						UDynamicObject* NewComponent = NewObject<UDynamicObject>(Actor);
+						if (NewComponent)
+						{
+							NewComponent->AttachToComponent(MeshComponent, FAttachmentTransformRules::KeepRelativeTransform);
+							NewComponent->RegisterComponent();
+							Actor->AddInstanceComponent(NewComponent);
+							bAttachedToMeshComponent = true;
+							bActorHasDynamic = true;
+							break; // Exit the loop since we've attached our component
+						}
+					}
+				}
+			}
+
+			if (!bAttachedToMeshComponent && !bActorHasDynamic)
+			{
+				// No suitable mesh component found and actor has no dynamics attach to the root component
+				UDynamicObject* NewComponent = NewObject<UDynamicObject>(Actor);
+				if (NewComponent)
+				{
+					NewComponent->AttachToComponent(Actor->GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
+					NewComponent->RegisterComponent();
+					Actor->AddInstanceComponent(NewComponent);
+				}
 			}
 		}
 	}

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/DynamicObjectManagerWidget.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/DynamicObjectManagerWidget.cpp
@@ -298,6 +298,29 @@ void SDynamicObjectManagerWidget::Construct(const FArguments& Args)
 					]
 				]
 			]
+
+			+ SVerticalBox::Slot() //upload buttons
+				.Padding(0, 0, 0, padding)
+				.HAlign(EHorizontalAlignment::HAlign_Center)
+				.VAlign(VAlign_Center)
+				.AutoHeight()
+				[
+					SNew(SHorizontalBox)
+					+ SHorizontalBox::Slot()
+				[
+					SNew(SBox)
+					.HeightOverride(32)
+				.WidthOverride(256)
+				[
+					SNew(SButton)
+					.IsEnabled(this, &SDynamicObjectManagerWidget::IsActorInSceneSelected)
+				.Text(FText::FromString("Add Dynamic Object Components To Selected Actors in Scene"))
+				.ToolTipText(FText::FromString("Add Dynamic Object Components To Selected Actors in Scene"))
+				.OnClicked_Raw(this, &SDynamicObjectManagerWidget::AssignDynamicsToActors)
+				]
+				]
+			]
+
 			]
 		];
 
@@ -649,6 +672,36 @@ FText SDynamicObjectManagerWidget::GetUploadInvalidCause() const
 	if (!FCognitiveEditorTools::GetInstance()->HasDeveloperKey()) { return FText::FromString("Developer Key is not set"); }
 	if (!FCognitiveEditorTools::GetInstance()->HasSetExportDirectory()) { return FText::FromString("Export Path is invalid"); }
 	return FText::GetEmpty();
+}
+
+FReply SDynamicObjectManagerWidget::AssignDynamicsToActors()
+{
+	for (FSelectionIterator It(GEditor->GetSelectedActorIterator()); It; ++It)
+	{
+		if (AActor* Actor = Cast<AActor>(*It))
+		{
+			//add dynamic object to actor root
+			//Actor->AddComponentByClass(TSubclassOf<UDynamicObject>
+			// Attach a UDynamicObject component to the actor
+			UDynamicObject* NewComponent = NewObject<UDynamicObject>(Actor);
+			if (NewComponent)
+			{
+				NewComponent->RegisterComponent(); // Make sure the component is registered
+				Actor->AddInstanceComponent(NewComponent); // Add it to the actor's components
+			}
+		}
+	}
+
+	return FReply::Handled();
+}
+
+bool SDynamicObjectManagerWidget::IsActorInSceneSelected() const
+{
+	if (!FCognitiveEditorTools::GetInstance()->HasDeveloperKey()) { return false; }
+	if (!FCognitiveEditorTools::GetInstance()->CurrentSceneHasSceneId()) { return false; }
+
+	USelection* SelectedActors = GEditor->GetSelectedActors();
+	return SelectedActors->Num() > 0;
 }
 
 EVisibility SDynamicObjectManagerWidget::GetSceneWarningVisibility() const

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/DynamicObjectManagerWidget.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/DynamicObjectManagerWidget.h
@@ -58,6 +58,10 @@ public:
 	FReply UploadSelectedDynamicObjects();
 	FReply UploadAllDynamicObjects();
 
+	//assign dynamics to objects in the scene
+	FReply AssignDynamicsToActors();
+	bool IsActorInSceneSelected() const;
+
 	EVisibility GetSceneWarningVisibility() const;
 
 	EVisibility SceneNotUploadedVisibility() const;


### PR DESCRIPTION
# Description

Added functionality to the dynamic object manager window to allow developers to select actors in the scene and assign dynamic objects to them all at once with the press of a button. Assigns dynamics to root if no meshes present, otherwise will find a mesh and apply one dynamic object to it. If a mesh already has one, will find other meshes on the actors without dynamic objects, otherwise do nothing. This applies to all meshes on the actor. 
Fixed bug with mesh names when assigning dynamic objects.
Fixed Dynamic Object Manager displaying multiple tracked meshes (dynamics) on one actor

Height Task ID(s) (If applicable): T - 9074, T-8060, T-9406

## Type of change

> Note: delete the lines that are not applicable and check the boxes (add a capital "X" in the square brackets) for the type of change.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
