### PR TITLE
Blueprint dynamics and dynamic manager window fixes

### DIFF
--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Cognitive3DEditor.Build.cs
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Cognitive3DEditor.Build.cs
@@ -72,6 +72,11 @@ public class Cognitive3DEditor : ModuleRules
 				"UnrealEd"
 			});
 
+        if (Target.bBuildEditor)
+        {
+            PrivateDependencyModuleNames.Add("Kismet");
+        }
+
         var pluginsDirectory = System.IO.Path.Combine(Target.ProjectFile.Directory.ToString(), "Plugins");
         //HP Omnicept
         if (System.IO.Directory.Exists(System.IO.Path.Combine(pluginsDirectory, "HPGlia")))

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
@@ -380,6 +380,85 @@ FProcHandle FCognitiveEditorTools::ExportAllDynamics()
 		}
 	}
 
+	//the dynamic we are looking for is actually on a blueprint in the project
+	//find the blueprint and get its dynamic object
+
+	for (const TSharedPtr<FDynamicData>& data : SceneDynamics)
+	{
+		// Iterate over all blueprints in the project
+		for (TObjectIterator<UBlueprint> It; It; ++It)
+		{
+			UBlueprint* Blueprint = *It;
+			if (Blueprint->GetName() == data->Name)
+			{
+				UE_LOG(LogTemp, Log, TEXT("Found blueprint: %s"), *Blueprint->GetName());
+				// Get the generated class from the blueprint
+				UClass* BlueprintClass = Blueprint->GeneratedClass;
+				if (BlueprintClass)
+				{
+					UE_LOG(LogTemp, Log, TEXT("Found blueprint class: %s"), *BlueprintClass->GetName());
+
+					if (BlueprintClass && BlueprintClass->IsChildOf(AActor::StaticClass()))
+					{
+						UE_LOG(LogTemp, Warning, TEXT("Found Actor-based Blueprint class: %s"), *BlueprintClass->GetName());
+
+						// Now, get the default object and access its components
+						AActor* DefaultActor = Cast<AActor>(BlueprintClass->GetDefaultObject());
+						if (DefaultActor)
+						{
+							UE_LOG(LogTemp, Warning, TEXT("Default actor is valid: %s"), *DefaultActor->GetName());
+
+							// Use Simple Construction Script to inspect the blueprint's components
+							if (UBlueprintGeneratedClass* BPGeneratedClass = Cast<UBlueprintGeneratedClass>(BlueprintClass))
+							{
+								UE_LOG(LogTemp, Warning, TEXT("Found BlueprintGeneratedClass: %s"), *BPGeneratedClass->GetName());
+								if (BPGeneratedClass->SimpleConstructionScript)
+								{
+									const TArray<USCS_Node*>& SCSNodes = BPGeneratedClass->SimpleConstructionScript->GetAllNodes();
+									UE_LOG(LogTemp, Warning, TEXT("Found %d SCS nodes in Blueprint: %s"), SCSNodes.Num(), *BlueprintClass->GetName());
+
+									// Iterate over the SCS nodes to find UDynamicObject components
+									for (USCS_Node* SCSNode : SCSNodes)
+									{
+										if (SCSNode && SCSNode->ComponentTemplate)
+										{
+											UActorComponent* ComponentTemplate = SCSNode->ComponentTemplate;
+											UE_LOG(LogTemp, Warning, TEXT("Found SCS Component: %s in Blueprint: %s"), *ComponentTemplate->GetName(), *BlueprintClass->GetName());
+
+											// Check if the component is a UDynamicObject
+											UDynamicObject* dynamicComponent = Cast<UDynamicObject>(ComponentTemplate);
+
+											if (dynamicComponent == NULL)
+											{
+												UE_LOG(LogTemp, Warning, TEXT("backup FCognitiveEditorTools::ExportDynamicData dynamicComponent is null"));
+												continue;
+											}
+											if (meshNames.Contains(dynamicComponent->MeshName))
+											{
+												continue;
+											}
+											UE_LOG(LogTemp, Log, TEXT("backup Found dynamic object component: %s"), *dynamicComponent->GetName());
+											bool exportActor = false;
+											if (data->MeshName == dynamicComponent->MeshName)
+											{
+												exportActor = true;
+											}
+											if (exportActor)
+											{
+												exportObjects.Add(dynamicComponent);
+												meshNames.Add(dynamicComponent->MeshName);
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
 	if (meshNames.Num() == 0)
 	{
 		return fph;
@@ -421,7 +500,7 @@ FReply FCognitiveEditorTools::ExportSelectedDynamics()
 	return FReply::Handled();
 }
 
-FProcHandle FCognitiveEditorTools::ExportDynamicData(TArray< TSharedPtr<FDynamicData>> dynamicData)
+FProcHandle FCognitiveEditorTools::ExportDynamicData(TArray<TSharedPtr<FDynamicData>> dynamicData)
 {
 	//find all meshes in scene that are contained in the dynamicData list
 
@@ -463,6 +542,87 @@ FProcHandle FCognitiveEditorTools::ExportDynamicData(TArray< TSharedPtr<FDynamic
 		}
 	}
 
+	//the dynamic we are looking for is actually on a blueprint in the project
+	//find the blueprint and get its dynamic object
+
+	for (const TSharedPtr<FDynamicData>& data : dynamicData)
+	{
+		// Iterate over all blueprints in the project
+		for (TObjectIterator<UBlueprint> It; It; ++It)
+		{
+			UBlueprint* Blueprint = *It;
+			if (Blueprint->GetName() == data->Name)
+			{
+				UE_LOG(LogTemp, Log, TEXT("Found blueprint: %s"), *Blueprint->GetName());
+				// Get the generated class from the blueprint
+				UClass* BlueprintClass = Blueprint->GeneratedClass;
+				if (BlueprintClass)
+				{
+					UE_LOG(LogTemp, Log, TEXT("Found blueprint class: %s"), *BlueprintClass->GetName());
+
+					if (BlueprintClass && BlueprintClass->IsChildOf(AActor::StaticClass()))
+					{
+						UE_LOG(LogTemp, Warning, TEXT("Found Actor-based Blueprint class: %s"), *BlueprintClass->GetName());
+
+						// Now, get the default object and access its components
+						AActor* DefaultActor = Cast<AActor>(BlueprintClass->GetDefaultObject());
+						if (DefaultActor)
+						{
+							UE_LOG(LogTemp, Warning, TEXT("Default actor is valid: %s"), *DefaultActor->GetName());
+
+							// Use Simple Construction Script to inspect the blueprint's components
+							if (UBlueprintGeneratedClass* BPGeneratedClass = Cast<UBlueprintGeneratedClass>(BlueprintClass))
+							{
+								UE_LOG(LogTemp, Warning, TEXT("Found BlueprintGeneratedClass: %s"), *BPGeneratedClass->GetName());
+								if (BPGeneratedClass->SimpleConstructionScript)
+								{
+									const TArray<USCS_Node*>& SCSNodes = BPGeneratedClass->SimpleConstructionScript->GetAllNodes();
+									UE_LOG(LogTemp, Warning, TEXT("Found %d SCS nodes in Blueprint: %s"), SCSNodes.Num(), *BlueprintClass->GetName());
+
+									// Iterate over the SCS nodes to find UDynamicObject components
+									for (USCS_Node* SCSNode : SCSNodes)
+									{
+										if (SCSNode && SCSNode->ComponentTemplate)
+										{
+											UActorComponent* ComponentTemplate = SCSNode->ComponentTemplate;
+											UE_LOG(LogTemp, Warning, TEXT("Found SCS Component: %s in Blueprint: %s"), *ComponentTemplate->GetName(), *BlueprintClass->GetName());
+
+											// Check if the component is a UDynamicObject
+											UDynamicObject* dynamicComponent = Cast<UDynamicObject>(ComponentTemplate);
+
+											if (dynamicComponent == NULL)
+											{
+												UE_LOG(LogTemp, Warning, TEXT("backup FCognitiveEditorTools::ExportDynamicData dynamicComponent is null"));
+												continue;
+											}
+											if (meshNames.Contains(dynamicComponent->MeshName))
+											{
+												continue;
+											}
+											UE_LOG(LogTemp, Log, TEXT("backup Found dynamic object component: %s"), *dynamicComponent->GetName());
+											bool exportActor = false;
+											if (data->MeshName == dynamicComponent->MeshName)
+											{
+												exportActor = true;
+											}
+											if (exportActor)
+											{
+												SelectionSetCache.Add(dynamicComponent);
+												meshNames.Add(dynamicComponent->MeshName);
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	//make sure to do this ^^ for exportall as well
+
 	return ExportDynamicObjectArray(SelectionSetCache);
 
 	//return FReply::Handled();
@@ -470,6 +630,12 @@ FProcHandle FCognitiveEditorTools::ExportDynamicData(TArray< TSharedPtr<FDynamic
 
 FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObject*> exportObjects)
 {
+	UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::ExportDynamicObjectArray"));
+
+	UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::ExportDynamicObjectArray exportObjects.Num() %d"), exportObjects.Num());
+
+	UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::ExportDynamicObjectArray BaseExportDirectory %s"), *BaseExportDirectory);
+
 	FProcHandle fph;
 
 	FVector originalLocation;
@@ -488,26 +654,152 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 
 		if (exportObjects[i] == NULL)
 		{
+			UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::ExportDynamicObjectArray export object is null"));
 			continue;
 		}
+		AActor* Owner = NULL;
+		bool isBlueprint = false;
+		UMeshComponent* bpMesh = NULL;
 		if (exportObjects[i]->GetOwner() == NULL)
 		{
-			continue;
+			UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::ExportDynamicObjectArray export object owner is null"));
+
+			
+
+			//if the owner is null, the object is likely a blueprint in the project
+			//find the blueprint and get its dynamic object
+
+			for (const TSharedPtr<FDynamicData>& data : SceneDynamics)
+			{
+				// Iterate over all blueprints in the project
+				for (TObjectIterator<UBlueprint> It; It; ++It)
+				{
+					UBlueprint* Blueprint = *It;
+					if (exportObjects[i]->MeshName == data->MeshName)
+					{
+						if (Blueprint->GetName() == data->Name)
+						{
+							UE_LOG(LogTemp, Log, TEXT("Found blueprint: %s"), *Blueprint->GetName());
+							// Get the generated class from the blueprint
+							UClass* BlueprintClass = Blueprint->GeneratedClass;
+							if (BlueprintClass)
+							{
+								UE_LOG(LogTemp, Log, TEXT("Found blueprint class: %s"), *BlueprintClass->GetName());
+
+								if (BlueprintClass && BlueprintClass->IsChildOf(AActor::StaticClass()))
+								{
+									UE_LOG(LogTemp, Warning, TEXT("Found Actor-based Blueprint class: %s"), *BlueprintClass->GetName());
+
+									// Now, get the default object and access its components
+									AActor* DefaultActor = Cast<AActor>(BlueprintClass->GetDefaultObject());
+									if (DefaultActor)
+									{
+										UE_LOG(LogTemp, Warning, TEXT("Default actor is valid: %s"), *DefaultActor->GetName());
+
+										// Use Simple Construction Script to inspect the blueprint's components
+										if (UBlueprintGeneratedClass* BPGeneratedClass = Cast<UBlueprintGeneratedClass>(BlueprintClass))
+										{
+											UE_LOG(LogTemp, Warning, TEXT("Found BlueprintGeneratedClass: %s"), *BPGeneratedClass->GetName());
+											if (BPGeneratedClass->SimpleConstructionScript)
+											{
+												const TArray<USCS_Node*>& SCSNodes = BPGeneratedClass->SimpleConstructionScript->GetAllNodes();
+												UE_LOG(LogTemp, Warning, TEXT("Found %d SCS nodes in Blueprint: %s"), SCSNodes.Num(), *BlueprintClass->GetName());
+
+												// Iterate over the SCS nodes to find UDynamicObject components
+												for (USCS_Node* SCSNode : SCSNodes)
+												{
+													if (SCSNode && SCSNode->ComponentTemplate)
+													{
+														UActorComponent* ComponentTemplate = SCSNode->ComponentTemplate;
+														UE_LOG(LogTemp, Warning, TEXT("Found SCS Component: %s in Blueprint: %s"), *ComponentTemplate->GetName(), *BlueprintClass->GetName());
+
+
+														//check if ComponentTemplate is a mesh
+														UMeshComponent* MeshComponent = Cast<UMeshComponent>(ComponentTemplate);
+														//verify that the mesh component is valid
+														if (MeshComponent == NULL)
+														{
+															UE_LOG(LogTemp, Warning, TEXT("backup FCognitiveEditorTools::ExportDynamicData MeshComponent is null"));
+														}
+														else
+														{
+															UE_LOG(LogTemp, Warning, TEXT("backup FCognitiveEditorTools::ExportDynamicData MeshComponent is valid"));
+														}
+														//if its valid, get the attached child component and log them
+														if (MeshComponent)
+														{
+															//const TArray<USCS_Node*>& SCSNodes = BPGeneratedClass->SimpleConstructionScript->GetAllNodes();
+
+															// Check its child nodes
+															const TArray<USCS_Node*>& ChildNodes = SCSNode->GetChildNodes();
+															for (USCS_Node* ChildNode : ChildNodes)
+															{
+																if (ChildNode && ChildNode->ComponentTemplate)
+																{
+																	// Assuming the dynamic object is of type UDynamicObjectComponent
+																	UDynamicObject* DynamicObjectComponent = Cast<UDynamicObject>(ChildNode->ComponentTemplate);
+																	if (DynamicObjectComponent)
+																	{
+																		UE_LOG(LogTemp, Log, TEXT("Found DynamicObjectComponent: %s"), *DynamicObjectComponent->GetName());
+																		// Do something with the dynamic object component
+																		if (DynamicObjectComponent->MeshName == data->MeshName)
+																		{
+																			UE_LOG(LogTemp, Log, TEXT("Found DynamicObjectComponent with matching MeshName: %s"), *DynamicObjectComponent->GetName());
+																			Owner = DefaultActor;
+																			isBlueprint = true;
+																			bpMesh = MeshComponent;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+
+			//both the regular owner and the found owners were null
+			if (Owner == NULL)
+			{
+				UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::ExportDynamicObjectArray Owner (from bp) is null"));
+				continue;
+			}
+
+			//continue;
 		}
 		if (exportObjects[i]->MeshName.IsEmpty())
 		{
+			UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::ExportDynamicObjectArray export object mesh name is empty"));
 			continue;
 		}
 
 		DynamicMeshNames.Add(exportObjects[i]->MeshName);
-
-		originalLocation = exportObjects[i]->GetOwner()->GetActorLocation();
-		originalRotation = exportObjects[i]->GetOwner()->GetActorRotation();
-		originalScale = exportObjects[i]->GetOwner()->GetActorScale();
-
-		exportObjects[i]->GetOwner()->SetActorLocation(FVector::ZeroVector);
-		exportObjects[i]->GetOwner()->SetActorRotation(FQuat::Identity);
-		exportObjects[i]->GetOwner()->SetActorScale3D(FVector::OneVector);
+		if (isBlueprint)
+		{
+			originalLocation = Owner->GetActorLocation();
+			originalRotation = Owner->GetActorRotation();
+			originalScale = Owner->GetActorScale();
+			Owner->SetActorLocation(FVector::ZeroVector);
+			Owner->SetActorRotation(FQuat::Identity);
+			Owner->SetActorScale3D(FVector::OneVector);
+		}
+		else
+		{
+			originalLocation = exportObjects[i]->GetOwner()->GetActorLocation();
+			originalRotation = exportObjects[i]->GetOwner()->GetActorRotation();
+			originalScale = exportObjects[i]->GetOwner()->GetActorScale();
+			exportObjects[i]->GetOwner()->SetActorLocation(FVector::ZeroVector);
+			exportObjects[i]->GetOwner()->SetActorRotation(FQuat::Identity);
+			exportObjects[i]->GetOwner()->SetActorScale3D(FVector::OneVector);
+		}
+		
 
 		FString justDirectory = GetDynamicsExportDirectory() + "/" + exportObjects[i]->MeshName;
 		FString tempObject;
@@ -529,39 +821,240 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 			PlatformFile.CreateDirectory(*justDirectory);
 		}
 
-
-		GEditor->SelectActor(exportObjects[i]->GetOwner(), true, false, true);
+		if (!isBlueprint)
+		{
+			GEditor->SelectActor(exportObjects[i]->GetOwner(), true, false, true);
+		}
 		ActorsExported++;
 		GLog->Log("FCognitiveEditorTools::ExportDynamicObjectArray dynamic output directory " + tempObject);
 
 
-
-		int DynamicObjectCount = 0;
-		//check if this D.O. is on an object with another D.O.
-		for (UActorComponent* Component : exportObjects[i]->GetOwner()->GetComponents())
+		if (isBlueprint)
 		{
-			if (Component->IsA(UDynamicObject::StaticClass()))
+			UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::ExportDynamicObjectArray isBlueprint: EXPORTING NOW"));
+			//use GLTFExporter Plugin
+
+						// Create export options
+			UGLTFExportOptions* ExportOptions = NewObject<UGLTFExportOptions>();
+
+			// Set custom export settings
+			ExportOptions->ExportUniformScale = 1.0f;
+			ExportOptions->bExportPreviewMesh = true;
+
+			// Texture compression settings
+			ExportOptions->TextureImageFormat = EGLTFTextureImageFormat::PNG;
+
+			// Create export task
+			UAssetExportTask* ExportTask = NewObject<UAssetExportTask>();
+			ExportTask->Filename = *tempObject;
+			if (UStaticMeshComponent* staticBpMeshComp = Cast<UStaticMeshComponent>(bpMesh))
 			{
-				DynamicObjectCount++;
+				ExportTask->Object = staticBpMeshComp->GetStaticMesh();
 			}
-		}
-
-		if (DynamicObjectCount > 1) //multiple D.O.s
-		{
-
-			UE_LOG(LogTemp, Warning, TEXT("FOUND MULTIPLE DYNAMIC OBJECTS"));
-
-			//if so, we check that each D.O. has a mesh parents
-			UMeshComponent* ParentMesh = Cast<UMeshComponent>(exportObjects[i]->GetAttachParent());
-
-			if (ParentMesh)
+			else if (USkeletalMeshComponent* skelBpMeshComp = Cast<USkeletalMeshComponent>(bpMesh))
 			{
-				// Check for Static Mesh Component
-				UStaticMeshComponent* StaticMeshComp = Cast<UStaticMeshComponent>(ParentMesh);
-				if (StaticMeshComp && StaticMeshComp->GetStaticMesh())
+				ExportTask->Object = skelBpMeshComp->SkeletalMesh;
+			}
+			ExportTask->bSelected = false;
+			ExportTask->bReplaceIdentical = true;
+			ExportTask->bPrompt = false;
+			ExportTask->bAutomated = true;
+			ExportTask->Options = ExportOptions;
+
+			// Perform export
+			ExportTask->Exporter->RunAssetExportTask(ExportTask);
+		}
+		else
+		{
+			int DynamicObjectCount = 0;
+			//check if this D.O. is on an object with another D.O.
+			for (UActorComponent* Component : exportObjects[i]->GetOwner()->GetComponents())
+			{
+				if (Component->IsA(UDynamicObject::StaticClass()))
 				{
-					UStaticMesh* StaticMeshAsset = StaticMeshComp->GetStaticMesh();
-					// Do something with StaticMeshAsset
+					DynamicObjectCount++;
+				}
+			}
+
+			if (DynamicObjectCount > 1) //multiple D.O.s //shouoldnt we then iterate through each mesh with a D.O. and export those?
+			{
+
+				UE_LOG(LogTemp, Warning, TEXT("FOUND MULTIPLE DYNAMIC OBJECTS"));
+
+				//if so, we check that each D.O. has a mesh parents
+				UMeshComponent* ParentMesh = Cast<UMeshComponent>(exportObjects[i]->GetAttachParent());
+
+				if (ParentMesh)
+				{
+					// Check for Static Mesh Component
+					UStaticMeshComponent* StaticMeshComp = Cast<UStaticMeshComponent>(ParentMesh);
+					if (StaticMeshComp && StaticMeshComp->GetStaticMesh())
+					{
+						UStaticMesh* StaticMeshAsset = StaticMeshComp->GetStaticMesh();
+						// Do something with StaticMeshAsset
+						//use GLTFExporter Plugin
+
+						// Create export options
+						UGLTFExportOptions* ExportOptions = NewObject<UGLTFExportOptions>();
+
+						// Set custom export settings
+						ExportOptions->ExportUniformScale = 1.0f;
+						ExportOptions->bExportPreviewMesh = true;
+
+						// Texture compression settings
+						ExportOptions->TextureImageFormat = EGLTFTextureImageFormat::PNG;
+
+						// Create export task
+						UAssetExportTask* ExportTask = NewObject<UAssetExportTask>();
+						ExportTask->Filename = *tempObject;
+						ExportTask->Object = StaticMeshAsset;
+						ExportTask->bSelected = false;
+						ExportTask->bReplaceIdentical = true;
+						ExportTask->bPrompt = false;
+						ExportTask->bAutomated = true;
+						ExportTask->Options = ExportOptions;
+
+						// Perform export
+						ExportTask->Exporter->RunAssetExportTask(ExportTask);
+					}
+
+					// Check for Skeletal Mesh Component
+					USkeletalMeshComponent* SkeletalMeshComp = Cast<USkeletalMeshComponent>(ParentMesh);
+					if (SkeletalMeshComp && SkeletalMeshComp->SkeletalMesh)
+					{
+						USkeletalMesh* SkeletalMeshAsset = SkeletalMeshComp->SkeletalMesh;
+						// Do something with SkeletalMeshAsset
+
+						//use GLTFExporter Plugin
+
+						// Create export options
+						UGLTFExportOptions* ExportOptions = NewObject<UGLTFExportOptions>();
+
+						// Set custom export settings
+						ExportOptions->ExportUniformScale = 1.0f;
+						ExportOptions->bExportPreviewMesh = true;
+
+						// Texture compression settings
+						ExportOptions->TextureImageFormat = EGLTFTextureImageFormat::PNG;
+
+						// Create export task
+						UAssetExportTask* ExportTask = NewObject<UAssetExportTask>();
+						ExportTask->Filename = *tempObject;
+						ExportTask->Object = SkeletalMeshAsset;
+						ExportTask->bSelected = false;
+						ExportTask->bReplaceIdentical = true;
+						ExportTask->bPrompt = false;
+						ExportTask->bAutomated = true;
+						ExportTask->Options = ExportOptions;
+
+						// Perform export
+						ExportTask->Exporter->RunAssetExportTask(ExportTask);
+					}
+
+				}
+				else //incorrect configuration of multiple D.O.s
+				{
+					FSuppressableWarningDialog::FSetupInfo DOExportSettingsInfo(LOCTEXT("DynamicObjectExportSettingsBody", "You are exporting a dynamic object on an actor with multiple dynamic objects, but they are not configured correctly. If you want to track multiple meshes on an actor with multiple dynamic objects, make sure each dynamic object is a child of its respective mesh"), LOCTEXT("DynamicObjectExportSettingsTitle", "Incorrect Dynamic Object Export Configuration"), "ExportSelectedDynamicsObjectsBody");
+					DOExportSettingsInfo.ConfirmText = LOCTEXT("Ok", "Ok");
+					DOExportSettingsInfo.CheckBoxText = FText();
+					FSuppressableWarningDialog DOExportSelectedDynamicMeshes(DOExportSettingsInfo);
+					DOExportSelectedDynamicMeshes.ShowModal();
+
+					continue;
+				}
+			}
+			else //only 1 D.O. proceed as normal
+			{
+				//if theres only 1 D.O. on the object, continue normally
+
+				//pawn export process needs to be able to group meshes somehow on D.O.s with 1 D.O. and multiple meshes
+				if (exportObjects[i]->GetOwner()->IsA(APawn::StaticClass()))
+				{
+					UE_LOG(LogTemp, Warning, TEXT("FOUND PAWN CLASS, EXPORTING MESH"));
+					UMeshComponent* pawnMesh = Cast<UMeshComponent>(exportObjects[i]->GetOwner()->GetComponentByClass(UMeshComponent::StaticClass()));
+					TArray<UActorComponent*> pawnMeshes;
+					exportObjects[i]->GetOwner()->GetComponents(UMeshComponent::StaticClass(), pawnMeshes);
+
+					TArray< UMeshComponent*> meshes;
+					for (int32 j = 0; j < pawnMeshes.Num(); j++)
+					{
+						UStaticMeshComponent* mesh = Cast<UStaticMeshComponent>(pawnMeshes[j]);
+						if (mesh == NULL)
+						{
+							continue;
+						}
+
+						ULevel* componentLevel = pawnMeshes[j]->GetComponentLevel();
+						if (componentLevel->bIsVisible == 0)
+						{
+							continue;
+							//not visible! possibly on a disabled sublevel
+						}
+
+						meshes.Add(mesh);
+					}
+
+					TArray<UActorComponent*> actorSkeletalComponents;
+					exportObjects[i]->GetOwner()->GetComponents(USkeletalMeshComponent::StaticClass(), actorSkeletalComponents);
+					for (int32 j = 0; j < actorSkeletalComponents.Num(); j++)
+					{
+						USkeletalMeshComponent* mesh = Cast<USkeletalMeshComponent>(actorSkeletalComponents[j]);
+						if (mesh == NULL)
+						{
+							continue;
+						}
+
+						ULevel* componentLevel = actorSkeletalComponents[j]->GetComponentLevel();
+						if (componentLevel->bIsVisible == 0)
+						{
+							continue;
+							//not visible! possibly on a disabled sublevel
+						}
+
+						meshes.Add(mesh);
+					}
+
+					//setup temp meshes package
+					UPackage* NewPackageName = CreatePackage(TEXT("/Game/TempMesh"));
+
+					if (meshes.Num() > 0)
+					{
+						//take the skeletal meshes that we set up earlier and use them to create a static mesh
+						UStaticMesh* tmpStatMesh = MeshUtilities.ConvertMeshesToStaticMesh(meshes, exportObjects[i]->GetOwner()->GetTransform(), NewPackageName->GetName());
+
+						//use GLTFExporter Plugin
+
+						// Create export options
+						UGLTFExportOptions* ExportOptions = NewObject<UGLTFExportOptions>();
+
+						// Set custom export settings
+						ExportOptions->ExportUniformScale = 1.0f;
+						ExportOptions->bExportPreviewMesh = true;
+
+						// Texture compression settings
+						ExportOptions->TextureImageFormat = EGLTFTextureImageFormat::PNG;
+
+						// Create export task
+						UAssetExportTask* ExportTask = NewObject<UAssetExportTask>();
+						ExportTask->Filename = *tempObject;
+						ExportTask->Object = tmpStatMesh;
+						ExportTask->bSelected = false;
+						ExportTask->bReplaceIdentical = true;
+						ExportTask->bPrompt = false;
+						ExportTask->bAutomated = true;
+						ExportTask->Options = ExportOptions;
+
+						// Perform export
+						ExportTask->Exporter->RunAssetExportTask(ExportTask);
+
+						TempAssetsToDelete.Add(tmpStatMesh);
+					}
+				}
+				else
+				{
+					//exports the currently selected actor(s)
+					UE_LOG(LogTemp, Warning, TEXT("DOING REGULAR MAP EXPORT"));
+
 					//use GLTFExporter Plugin
 
 					// Create export options
@@ -576,9 +1069,10 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 
 					// Create export task
 					UAssetExportTask* ExportTask = NewObject<UAssetExportTask>();
+					ExportTask->Object = GWorld;
+					ExportTask->Exporter = NewObject<UGLTFLevelExporter>();
 					ExportTask->Filename = *tempObject;
-					ExportTask->Object = StaticMeshAsset;
-					ExportTask->bSelected = false;
+					ExportTask->bSelected = true;
 					ExportTask->bReplaceIdentical = true;
 					ExportTask->bPrompt = false;
 					ExportTask->bAutomated = true;
@@ -587,177 +1081,16 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 					// Perform export
 					ExportTask->Exporter->RunAssetExportTask(ExportTask);
 				}
-
-				// Check for Skeletal Mesh Component
-				USkeletalMeshComponent* SkeletalMeshComp = Cast<USkeletalMeshComponent>(ParentMesh);
-				if (SkeletalMeshComp && SkeletalMeshComp->SkeletalMesh)
-				{
-					USkeletalMesh* SkeletalMeshAsset = SkeletalMeshComp->SkeletalMesh;
-					// Do something with SkeletalMeshAsset
-
-					//use GLTFExporter Plugin
-
-					// Create export options
-					UGLTFExportOptions* ExportOptions = NewObject<UGLTFExportOptions>();
-
-					// Set custom export settings
-					ExportOptions->ExportUniformScale = 1.0f;
-					ExportOptions->bExportPreviewMesh = true;
-
-					// Texture compression settings
-					ExportOptions->TextureImageFormat = EGLTFTextureImageFormat::PNG;
-
-					// Create export task
-					UAssetExportTask* ExportTask = NewObject<UAssetExportTask>();
-					ExportTask->Filename = *tempObject;
-					ExportTask->Object = SkeletalMeshAsset;
-					ExportTask->bSelected = false;
-					ExportTask->bReplaceIdentical = true;
-					ExportTask->bPrompt = false;
-					ExportTask->bAutomated = true;
-					ExportTask->Options = ExportOptions;
-
-					// Perform export
-					ExportTask->Exporter->RunAssetExportTask(ExportTask);
-				}
-
-			}
-			else //incorrect configuration of multiple D.O.s
-			{
-				FSuppressableWarningDialog::FSetupInfo DOExportSettingsInfo(LOCTEXT("DynamicObjectExportSettingsBody", "You are exporting a dynamic object on an actor with multiple dynamic objects, but they are not configured correctly. If you want to track multiple meshes on an actor with multiple dynamic objects, make sure each dynamic object is a child of its respective mesh"), LOCTEXT("DynamicObjectExportSettingsTitle", "Incorrect Dynamic Object Export Configuration"), "ExportSelectedDynamicsObjectsBody");
-				DOExportSettingsInfo.ConfirmText = LOCTEXT("Ok", "Ok");
-				DOExportSettingsInfo.CheckBoxText = FText();
-				FSuppressableWarningDialog DOExportSelectedDynamicMeshes(DOExportSettingsInfo);
-				DOExportSelectedDynamicMeshes.ShowModal();
-
-				continue;
 			}
 		}
-		else //only 1 D.O. proceed as normal
+
+		if (!isBlueprint)
 		{
-			//if theres only 1 D.O. on the object, continue normally
-
-			//pawn export process needs to be able to group meshes somehow on D.O.s with 1 D.O. and multiple meshes
-			if (exportObjects[i]->GetOwner()->IsA(APawn::StaticClass()))
-			{
-				UE_LOG(LogTemp, Warning, TEXT("FOUND PAWN CLASS, EXPORTING MESH"));
-				UMeshComponent* pawnMesh = Cast<UMeshComponent>(exportObjects[i]->GetOwner()->GetComponentByClass(UMeshComponent::StaticClass()));
-				TArray<UActorComponent*> pawnMeshes;
-				exportObjects[i]->GetOwner()->GetComponents(UMeshComponent::StaticClass(), pawnMeshes);
-
-				TArray< UMeshComponent*> meshes;
-				for (int32 j = 0; j < pawnMeshes.Num(); j++)
-				{
-					UStaticMeshComponent* mesh = Cast<UStaticMeshComponent>(pawnMeshes[j]);
-					if (mesh == NULL)
-					{
-						continue;
-					}
-
-					ULevel* componentLevel = pawnMeshes[j]->GetComponentLevel();
-					if (componentLevel->bIsVisible == 0)
-					{
-						continue;
-						//not visible! possibly on a disabled sublevel
-					}
-
-					meshes.Add(mesh);
-				}
-
-				TArray<UActorComponent*> actorSkeletalComponents;
-				exportObjects[i]->GetOwner()->GetComponents(USkeletalMeshComponent::StaticClass(), actorSkeletalComponents);
-				for (int32 j = 0; j < actorSkeletalComponents.Num(); j++)
-				{
-					USkeletalMeshComponent* mesh = Cast<USkeletalMeshComponent>(actorSkeletalComponents[j]);
-					if (mesh == NULL)
-					{
-						continue;
-					}
-
-					ULevel* componentLevel = actorSkeletalComponents[j]->GetComponentLevel();
-					if (componentLevel->bIsVisible == 0)
-					{
-						continue;
-						//not visible! possibly on a disabled sublevel
-					}
-
-					meshes.Add(mesh);
-				}
-
-				//setup temp meshes package
-				UPackage* NewPackageName = CreatePackage(TEXT("/Game/TempMesh"));
-
-				if (meshes.Num() > 0)
-				{
-					//take the skeletal meshes that we set up earlier and use them to create a static mesh
-					UStaticMesh* tmpStatMesh = MeshUtilities.ConvertMeshesToStaticMesh(meshes, exportObjects[i]->GetOwner()->GetTransform(), NewPackageName->GetName());
-
-					//use GLTFExporter Plugin
-
-					// Create export options
-					UGLTFExportOptions* ExportOptions = NewObject<UGLTFExportOptions>();
-
-					// Set custom export settings
-					ExportOptions->ExportUniformScale = 1.0f;
-					ExportOptions->bExportPreviewMesh = true;
-
-					// Texture compression settings
-					ExportOptions->TextureImageFormat = EGLTFTextureImageFormat::PNG;
-
-					// Create export task
-					UAssetExportTask* ExportTask = NewObject<UAssetExportTask>();
-					ExportTask->Filename = *tempObject;
-					ExportTask->Object = tmpStatMesh;
-					ExportTask->bSelected = false;
-					ExportTask->bReplaceIdentical = true;
-					ExportTask->bPrompt = false;
-					ExportTask->bAutomated = true;
-					ExportTask->Options = ExportOptions;
-
-					// Perform export
-					ExportTask->Exporter->RunAssetExportTask(ExportTask);
-
-					TempAssetsToDelete.Add(tmpStatMesh);
-				}
-			}
-			else
-			{
-				//exports the currently selected actor(s)
-				UE_LOG(LogTemp, Warning, TEXT("DOING REGULAR MAP EXPORT"));
-
-				//use GLTFExporter Plugin
-
-				// Create export options
-				UGLTFExportOptions* ExportOptions = NewObject<UGLTFExportOptions>();
-
-				// Set custom export settings
-				ExportOptions->ExportUniformScale = 1.0f;
-				ExportOptions->bExportPreviewMesh = true;
-
-				// Texture compression settings
-				ExportOptions->TextureImageFormat = EGLTFTextureImageFormat::PNG;
-
-				// Create export task
-				UAssetExportTask* ExportTask = NewObject<UAssetExportTask>();
-				ExportTask->Object = GWorld;
-				ExportTask->Exporter = NewObject<UGLTFLevelExporter>();
-				ExportTask->Filename = *tempObject;
-				ExportTask->bSelected = true;
-				ExportTask->bReplaceIdentical = true;
-				ExportTask->bPrompt = false;
-				ExportTask->bAutomated = true;
-				ExportTask->Options = ExportOptions;
-
-				// Perform export
-				ExportTask->Exporter->RunAssetExportTask(ExportTask);
-			}
+			//reset dynamic back to original transform
+			exportObjects[i]->GetOwner()->SetActorLocation(originalLocation);
+			exportObjects[i]->GetOwner()->SetActorRotation(originalRotation);
+			exportObjects[i]->GetOwner()->SetActorScale3D(originalScale);
 		}
-
-
-		//reset dynamic back to original transform
-		exportObjects[i]->GetOwner()->SetActorLocation(originalLocation);
-		exportObjects[i]->GetOwner()->SetActorRotation(originalRotation);
-		exportObjects[i]->GetOwner()->SetActorScale3D(originalScale);
 
 		//check that files were actually exported
 		if (PlatformFile.FileExists(*tempObject))
@@ -766,6 +1099,7 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 		}
 		else
 		{
+			UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::ExportDynamicObjectArray export object file not found"));
 			//don't export screenshots or save materials unless export popup was confirmed
 			continue;
 		}
@@ -781,7 +1115,7 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 				break;
 			}
 		}
-		if (perspectiveView != NULL)
+		if (perspectiveView != NULL && !isBlueprint)
 		{
 			FVector startPosition = perspectiveView->GetViewLocation();
 			FRotator startRotation = perspectiveView->GetViewRotation();
@@ -810,7 +1144,7 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 
 	if (RawExportFilesFound == 0)
 	{
-		UE_LOG(LogTemp, Error, TEXT("FCognitiveEditorTools::ExportDynamicObjectArray Cancelled mesh export"));
+		UE_LOG(LogTemp, Error, TEXT("FCognitiveEditorTools::ExportDynamicObjectArray Cancelled mesh export")); ////
 		return fph;
 	}
 
@@ -924,6 +1258,8 @@ FReply FCognitiveEditorTools::SetUniqueDynamicIds()
 
 FReply FCognitiveEditorTools::UploadDynamicsManifest()
 {
+	//UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::UploadDynamicsManifest started"));
+
 	TArray<UDynamicObject*> dynamics;
 
 	//get all the dynamic objects in the scene
@@ -931,18 +1267,67 @@ FReply FCognitiveEditorTools::UploadDynamicsManifest()
 	{
 		// Same as with the Object Iterator, access the subclass instance with the * or -> operators.
 		//AStaticMeshActor *Mesh = *ActorItr;
+		//UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::UploadDynamicsManifest found actor %s"), *ActorItr->GetName());
+		//check all compoenents on the actor in case there are multiple dynamic objects
+		for (UActorComponent* actorComponent : ActorItr->GetComponents())
+		{
+			//UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::UploadDynamicsManifest found component %s"), *actorComponent->GetName());
+			if (actorComponent->IsA(UDynamicObject::StaticClass()))
+			{
+				//UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::UploadDynamicsManifest found dynamic object"));
+				UDynamicObject* dynamic = Cast<UDynamicObject>(actorComponent);
+				if (dynamic == NULL)
+				{
+					continue;
+				}
+				//UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::UploadDynamicsManifest found dynamic object %s"), *dynamic->MeshName);
+				dynamics.Add(dynamic);
+			}
+		}
+	}
 
-		UActorComponent* actorComponent = (*ActorItr)->GetComponentByClass(UDynamicObject::StaticClass());
-		if (actorComponent == NULL)
+	//get the blueprint dynamics in the project and add them to the list
+	for (const TSharedPtr<FDynamicData>& data : SceneDynamics)
+	{
+		// Iterate over all blueprints in the project
+		for (TObjectIterator<UBlueprint> It; It; ++It)
 		{
-			continue;
+			UBlueprint* Blueprint = *It;
+			if (Blueprint->GetName() == data->Name)
+			{
+				// Get the generated class from the blueprint
+				UClass* BlueprintClass = Blueprint->GeneratedClass;
+				if (BlueprintClass)
+				{
+					// Now, get the default object and access its components
+					AActor* DefaultActor = Cast<AActor>(BlueprintClass->GetDefaultObject());
+					if (DefaultActor)
+					{
+						// Use Simple Construction Script to inspect the blueprint's components
+						if (UBlueprintGeneratedClass* BPGeneratedClass = Cast<UBlueprintGeneratedClass>(BlueprintClass))
+						{
+							const TArray<USCS_Node*>& SCSNodes = BPGeneratedClass->SimpleConstructionScript->GetAllNodes();
+							// Iterate over the SCS nodes to find UDynamicObject components
+							for (USCS_Node* SCSNode : SCSNodes)
+							{
+								if (SCSNode && SCSNode->ComponentTemplate)
+								{
+									// Check if the component is a UDynamicObject
+									UDynamicObject* dynamicComponent = Cast<UDynamicObject>(SCSNode->ComponentTemplate);
+									if (dynamicComponent)
+									{
+										if (dynamicComponent->MeshName == data->MeshName && !dynamics.Contains(dynamicComponent))
+										{
+											dynamics.Add(dynamicComponent);
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
 		}
-		UDynamicObject* dynamic = Cast<UDynamicObject>(actorComponent);
-		if (dynamic == NULL)
-		{
-			continue;
-		}
-		dynamics.Add(dynamic);
 	}
 
 	GLog->Log("Cognitive3D Tools uploading manifest for " + FString::FromInt(dynamics.Num()) + " objects");
@@ -954,6 +1339,22 @@ FReply FCognitiveEditorTools::UploadDynamicsManifest()
 
 FReply FCognitiveEditorTools::UploadSelectedDynamicsManifest(TArray<UDynamicObject*> dynamics)
 {
+	UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::UploadSelectedDynamicsManifest started"));
+	
+	UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::UploadSelectedDynamicsManifest found %d dynamics"), dynamics.Num());
+
+	for (const UDynamicObject* dynamicObject : dynamics)
+	{
+		if (dynamicObject)
+		{
+			UE_LOG(LogTemp, Log, TEXT("Dynamic Object: %s"), *dynamicObject->GetName());
+		}
+		else
+		{
+			UE_LOG(LogTemp, Warning, TEXT("Null Dynamic Object in array"));
+		}
+	}
+
 	bool wroteAnyObjects = false;
 
 	//split up dynamics and make a web request every 250 items, up to 99 calls
@@ -974,16 +1375,141 @@ FReply FCognitiveEditorTools::UploadSelectedDynamicsManifest(TArray<UDynamicObje
 			//if they have a customid -> add them to the objectmanifest string
 			if (dynamics[q]->IdSourceType == EIdSourceType::CustomId && dynamics[q]->CustomId != "")
 			{
-				FVector location = dynamics[q]->GetComponentLocation();
-				FQuat rotation = dynamics[q]->GetComponentQuat();
-				FVector scale = dynamics[q]->GetComponentScale();
+				AActor* Owner = NULL;
+				bool isBlueprint = false;
+				UMeshComponent* bpMesh = NULL;
+
+				//get this dynamic's blueprint, owner, and check a boolean to see if it is a blueprint
+				for (const TSharedPtr<FDynamicData>& data : SceneDynamics)
+				{
+					// Iterate over all blueprints in the project
+					for (TObjectIterator<UBlueprint> It; It; ++It)
+					{
+						UBlueprint* Blueprint = *It;
+						if (dynamics[q]->MeshName == data->MeshName)
+						{
+							if (Blueprint->GetName() == data->Name)
+							{
+								UE_LOG(LogTemp, Log, TEXT("Found blueprint: %s"), *Blueprint->GetName());
+								// Get the generated class from the blueprint
+								UClass* BlueprintClass = Blueprint->GeneratedClass;
+								if (BlueprintClass)
+								{
+									UE_LOG(LogTemp, Log, TEXT("Found blueprint class: %s"), *BlueprintClass->GetName());
+
+									if (BlueprintClass && BlueprintClass->IsChildOf(AActor::StaticClass()))
+									{
+										UE_LOG(LogTemp, Warning, TEXT("Found Actor-based Blueprint class: %s"), *BlueprintClass->GetName());
+
+										// Now, get the default object and access its components
+										AActor* DefaultActor = Cast<AActor>(BlueprintClass->GetDefaultObject());
+										if (DefaultActor)
+										{
+											UE_LOG(LogTemp, Warning, TEXT("Default actor is valid: %s"), *DefaultActor->GetName());
+
+											// Use Simple Construction Script to inspect the blueprint's components
+											if (UBlueprintGeneratedClass* BPGeneratedClass = Cast<UBlueprintGeneratedClass>(BlueprintClass))
+											{
+												UE_LOG(LogTemp, Warning, TEXT("Found BlueprintGeneratedClass: %s"), *BPGeneratedClass->GetName());
+												if (BPGeneratedClass->SimpleConstructionScript)
+												{
+													const TArray<USCS_Node*>& SCSNodes = BPGeneratedClass->SimpleConstructionScript->GetAllNodes();
+													UE_LOG(LogTemp, Warning, TEXT("Found %d SCS nodes in Blueprint: %s"), SCSNodes.Num(), *BlueprintClass->GetName());
+
+													// Iterate over the SCS nodes to find UDynamicObject components
+													for (USCS_Node* SCSNode : SCSNodes)
+													{
+														if (SCSNode && SCSNode->ComponentTemplate)
+														{
+															UActorComponent* ComponentTemplate = SCSNode->ComponentTemplate;
+															UE_LOG(LogTemp, Warning, TEXT("Found SCS Component: %s in Blueprint: %s"), *ComponentTemplate->GetName(), *BlueprintClass->GetName());
+
+															//check if ComponentTemplate is a mesh
+															UMeshComponent* MeshComponent = Cast<UMeshComponent>(ComponentTemplate);
+															//verify that the mesh component is valid
+															if (MeshComponent == NULL)
+															{
+																UE_LOG(LogTemp, Warning, TEXT("backup FCognitiveEditorTools::ExportDynamicData MeshComponent is null"));
+
+															}
+															else
+															{
+																UE_LOG(LogTemp, Warning, TEXT("backup FCognitiveEditorTools::ExportDynamicData MeshComponent is valid"));
+
+																//Owner = DefaultActor;
+															}
+															//if its valid, get the attached child component and log them
+															if (MeshComponent)
+															{
+																//const TArray<USCS_Node*>& SCSNodes = BPGeneratedClass->SimpleConstructionScript->GetAllNodes();
+
+																// Check its child nodes
+																const TArray<USCS_Node*>& ChildNodes = SCSNode->GetChildNodes();
+																for (USCS_Node* ChildNode : ChildNodes)
+																{
+																	if (ChildNode && ChildNode->ComponentTemplate)
+																	{
+																		// Assuming the dynamic object is of type UDynamicObjectComponent
+																		UDynamicObject* DynamicObjectComponent = Cast<UDynamicObject>(ChildNode->ComponentTemplate);
+																		if (DynamicObjectComponent)
+																		{
+																			UE_LOG(LogTemp, Log, TEXT("Found DynamicObjectComponent: %s"), *DynamicObjectComponent->GetName());
+																			// Do something with the dynamic object component
+																			if (DynamicObjectComponent->MeshName == data->MeshName)
+																			{
+																				UE_LOG(LogTemp, Log, TEXT("Found DynamicObjectComponent with matching MeshName: %s"), *DynamicObjectComponent->GetName());
+																				Owner = DefaultActor;
+																				isBlueprint = true;
+																				bpMesh = MeshComponent;
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+
+				FVector location;
+				FQuat rotation;
+				FVector scale;
+
+				if (!isBlueprint)
+				{
+					location = dynamics[q]->GetComponentLocation();
+					rotation = dynamics[q]->GetComponentQuat();
+					scale = dynamics[q]->GetComponentScale();
+				}
+				else
+				{
+					location = FVector::ZeroVector;
+					rotation = FQuat::Identity;
+					scale = FVector::OneVector;
+				}
 
 				wroteAnyObjects = true;
 				dynamicsCount++;
+				FString isController = dynamics[q]->IsController ? "true" : "false";
 				objectManifest += "{";
 				objectManifest += "\"id\":\"" + dynamics[q]->CustomId + "\",";
 				objectManifest += "\"mesh\":\"" + dynamics[q]->MeshName + "\",";
-				objectManifest += "\"name\":\"" + dynamics[q]->GetOwner()->GetName() + "\",";
+				if (isBlueprint)
+				{
+					objectManifest += "\"name\":\"" + Owner->GetName() + "\",";
+				}
+				else
+				{
+					objectManifest += "\"name\":\"" + dynamics[q]->GetOwner()->GetName() + "\",";
+				}
+                objectManifest += "\"isController\":\"" + isController + "\",";
 				objectManifest += "\"scaleCustom\":[" + FString::SanitizeFloat(scale.X) + "," + FString::SanitizeFloat(scale.Z) + "," + FString::SanitizeFloat(scale.Y) + "],";
 				objectManifest += "\"initialPosition\":[" + FString::SanitizeFloat(-location.X) + "," + FString::SanitizeFloat(location.Z) + "," + FString::SanitizeFloat(location.Y) + "],";
 				objectManifest += "\"initialRotation\":[" + FString::SanitizeFloat(-rotation.X) + "," + FString::SanitizeFloat(rotation.Z) + "," + FString::SanitizeFloat(-rotation.Y) + "," + FString::SanitizeFloat(rotation.W) + "]";
@@ -1020,7 +1546,11 @@ FReply FCognitiveEditorTools::UploadSelectedDynamicsManifest(TArray<UDynamicObje
 			GLog->Log("CognitiveTools::UploadDynamicsManifest current scene does not have valid version number. GetSceneVersions and try again");
 			return FReply::Handled();
 		}
-
+		if (!objectManifest.Contains("mesh"))
+		{
+			GLog->Log("CognitiveTools::UploadDynamicsManifest object manifest does not contain mesh name");
+			return FReply::Handled();
+		}
 		FString url = PostDynamicObjectManifest(currentSceneData->Id, currentSceneData->VersionNumber);
 
 		//send manifest to api/objects/sceneid
@@ -2040,7 +2570,7 @@ void FCognitiveEditorTools::OnUploadObjectCompleted(FHttpRequestPtr Request, FHt
 	if (WizardUploading && OutstandingDynamicUploadRequests <= 0)
 	{
 		//upload manifest
-		UploadDynamicsManifest();
+		UploadDynamicsManifest(); ////
 	}
 }
 
@@ -2319,7 +2849,7 @@ FReply FCognitiveEditorTools::RefreshDisplayDynamicObjectsCountInScene()
 	Filter.ClassNames.Add(UDynamicIdPoolAsset::StaticClass()->GetFName());
 #elif ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION == 0 
 	Filter.ClassNames.Add(UDynamicIdPoolAsset::StaticClass()->GetFName());
-#elif ENGINE_MAJOR_VERSION == 5 && (ENGINE_MINOR_VERSION == 2 || ENGINE_MINOR_VERSION == 3 || ENGINE_MINOR_VERSION == 1)
+#elif ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
 	Filter.ClassPaths.Add(UDynamicIdPoolAsset::StaticClass()->GetClassPathName());
 #endif
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
@@ -391,31 +391,25 @@ FProcHandle FCognitiveEditorTools::ExportAllDynamics()
 			UBlueprint* Blueprint = *It;
 			if (Blueprint->GetName() == data->Name)
 			{
-				UE_LOG(LogTemp, Log, TEXT("Found blueprint: %s"), *Blueprint->GetName());
 				// Get the generated class from the blueprint
 				UClass* BlueprintClass = Blueprint->GeneratedClass;
 				if (BlueprintClass)
 				{
-					UE_LOG(LogTemp, Log, TEXT("Found blueprint class: %s"), *BlueprintClass->GetName());
 
 					if (BlueprintClass && BlueprintClass->IsChildOf(AActor::StaticClass()))
 					{
-						UE_LOG(LogTemp, Warning, TEXT("Found Actor-based Blueprint class: %s"), *BlueprintClass->GetName());
 
 						// Now, get the default object and access its components
 						AActor* DefaultActor = Cast<AActor>(BlueprintClass->GetDefaultObject());
 						if (DefaultActor)
 						{
-							UE_LOG(LogTemp, Warning, TEXT("Default actor is valid: %s"), *DefaultActor->GetName());
 
 							// Use Simple Construction Script to inspect the blueprint's components
 							if (UBlueprintGeneratedClass* BPGeneratedClass = Cast<UBlueprintGeneratedClass>(BlueprintClass))
 							{
-								UE_LOG(LogTemp, Warning, TEXT("Found BlueprintGeneratedClass: %s"), *BPGeneratedClass->GetName());
 								if (BPGeneratedClass->SimpleConstructionScript)
 								{
 									const TArray<USCS_Node*>& SCSNodes = BPGeneratedClass->SimpleConstructionScript->GetAllNodes();
-									UE_LOG(LogTemp, Warning, TEXT("Found %d SCS nodes in Blueprint: %s"), SCSNodes.Num(), *BlueprintClass->GetName());
 
 									// Iterate over the SCS nodes to find UDynamicObject components
 									for (USCS_Node* SCSNode : SCSNodes)
@@ -423,21 +417,18 @@ FProcHandle FCognitiveEditorTools::ExportAllDynamics()
 										if (SCSNode && SCSNode->ComponentTemplate)
 										{
 											UActorComponent* ComponentTemplate = SCSNode->ComponentTemplate;
-											UE_LOG(LogTemp, Warning, TEXT("Found SCS Component: %s in Blueprint: %s"), *ComponentTemplate->GetName(), *BlueprintClass->GetName());
 
 											// Check if the component is a UDynamicObject
 											UDynamicObject* dynamicComponent = Cast<UDynamicObject>(ComponentTemplate);
 
 											if (dynamicComponent == NULL)
 											{
-												UE_LOG(LogTemp, Warning, TEXT("backup FCognitiveEditorTools::ExportDynamicData dynamicComponent is null"));
 												continue;
 											}
 											if (meshNames.Contains(dynamicComponent->MeshName))
 											{
 												continue;
 											}
-											UE_LOG(LogTemp, Log, TEXT("backup Found dynamic object component: %s"), *dynamicComponent->GetName());
 											bool exportActor = false;
 											if (data->MeshName == dynamicComponent->MeshName)
 											{
@@ -553,31 +544,25 @@ FProcHandle FCognitiveEditorTools::ExportDynamicData(TArray<TSharedPtr<FDynamicD
 			UBlueprint* Blueprint = *It;
 			if (Blueprint->GetName() == data->Name)
 			{
-				UE_LOG(LogTemp, Log, TEXT("Found blueprint: %s"), *Blueprint->GetName());
 				// Get the generated class from the blueprint
 				UClass* BlueprintClass = Blueprint->GeneratedClass;
 				if (BlueprintClass)
 				{
-					UE_LOG(LogTemp, Log, TEXT("Found blueprint class: %s"), *BlueprintClass->GetName());
 
 					if (BlueprintClass && BlueprintClass->IsChildOf(AActor::StaticClass()))
 					{
-						UE_LOG(LogTemp, Warning, TEXT("Found Actor-based Blueprint class: %s"), *BlueprintClass->GetName());
 
 						// Now, get the default object and access its components
 						AActor* DefaultActor = Cast<AActor>(BlueprintClass->GetDefaultObject());
 						if (DefaultActor)
 						{
-							UE_LOG(LogTemp, Warning, TEXT("Default actor is valid: %s"), *DefaultActor->GetName());
 
 							// Use Simple Construction Script to inspect the blueprint's components
 							if (UBlueprintGeneratedClass* BPGeneratedClass = Cast<UBlueprintGeneratedClass>(BlueprintClass))
 							{
-								UE_LOG(LogTemp, Warning, TEXT("Found BlueprintGeneratedClass: %s"), *BPGeneratedClass->GetName());
 								if (BPGeneratedClass->SimpleConstructionScript)
 								{
 									const TArray<USCS_Node*>& SCSNodes = BPGeneratedClass->SimpleConstructionScript->GetAllNodes();
-									UE_LOG(LogTemp, Warning, TEXT("Found %d SCS nodes in Blueprint: %s"), SCSNodes.Num(), *BlueprintClass->GetName());
 
 									// Iterate over the SCS nodes to find UDynamicObject components
 									for (USCS_Node* SCSNode : SCSNodes)
@@ -585,21 +570,18 @@ FProcHandle FCognitiveEditorTools::ExportDynamicData(TArray<TSharedPtr<FDynamicD
 										if (SCSNode && SCSNode->ComponentTemplate)
 										{
 											UActorComponent* ComponentTemplate = SCSNode->ComponentTemplate;
-											UE_LOG(LogTemp, Warning, TEXT("Found SCS Component: %s in Blueprint: %s"), *ComponentTemplate->GetName(), *BlueprintClass->GetName());
 
 											// Check if the component is a UDynamicObject
 											UDynamicObject* dynamicComponent = Cast<UDynamicObject>(ComponentTemplate);
 
 											if (dynamicComponent == NULL)
 											{
-												UE_LOG(LogTemp, Warning, TEXT("backup FCognitiveEditorTools::ExportDynamicData dynamicComponent is null"));
 												continue;
 											}
 											if (meshNames.Contains(dynamicComponent->MeshName))
 											{
 												continue;
 											}
-											UE_LOG(LogTemp, Log, TEXT("backup Found dynamic object component: %s"), *dynamicComponent->GetName());
 											bool exportActor = false;
 											if (data->MeshName == dynamicComponent->MeshName)
 											{
@@ -630,11 +612,6 @@ FProcHandle FCognitiveEditorTools::ExportDynamicData(TArray<TSharedPtr<FDynamicD
 
 FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObject*> exportObjects)
 {
-	UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::ExportDynamicObjectArray"));
-
-	UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::ExportDynamicObjectArray exportObjects.Num() %d"), exportObjects.Num());
-
-	UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::ExportDynamicObjectArray BaseExportDirectory %s"), *BaseExportDirectory);
 
 	FProcHandle fph;
 
@@ -654,7 +631,6 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 
 		if (exportObjects[i] == NULL)
 		{
-			UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::ExportDynamicObjectArray export object is null"));
 			continue;
 		}
 		AActor* Owner = NULL;
@@ -662,10 +638,6 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 		UMeshComponent* bpMesh = NULL;
 		if (exportObjects[i]->GetOwner() == NULL)
 		{
-			UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::ExportDynamicObjectArray export object owner is null"));
-
-			
-
 			//if the owner is null, the object is likely a blueprint in the project
 			//find the blueprint and get its dynamic object
 
@@ -679,31 +651,25 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 					{
 						if (Blueprint->GetName() == data->Name)
 						{
-							UE_LOG(LogTemp, Log, TEXT("Found blueprint: %s"), *Blueprint->GetName());
 							// Get the generated class from the blueprint
 							UClass* BlueprintClass = Blueprint->GeneratedClass;
 							if (BlueprintClass)
 							{
-								UE_LOG(LogTemp, Log, TEXT("Found blueprint class: %s"), *BlueprintClass->GetName());
 
 								if (BlueprintClass && BlueprintClass->IsChildOf(AActor::StaticClass()))
 								{
-									UE_LOG(LogTemp, Warning, TEXT("Found Actor-based Blueprint class: %s"), *BlueprintClass->GetName());
 
 									// Now, get the default object and access its components
 									AActor* DefaultActor = Cast<AActor>(BlueprintClass->GetDefaultObject());
 									if (DefaultActor)
 									{
-										UE_LOG(LogTemp, Warning, TEXT("Default actor is valid: %s"), *DefaultActor->GetName());
 
 										// Use Simple Construction Script to inspect the blueprint's components
 										if (UBlueprintGeneratedClass* BPGeneratedClass = Cast<UBlueprintGeneratedClass>(BlueprintClass))
 										{
-											UE_LOG(LogTemp, Warning, TEXT("Found BlueprintGeneratedClass: %s"), *BPGeneratedClass->GetName());
 											if (BPGeneratedClass->SimpleConstructionScript)
 											{
 												const TArray<USCS_Node*>& SCSNodes = BPGeneratedClass->SimpleConstructionScript->GetAllNodes();
-												UE_LOG(LogTemp, Warning, TEXT("Found %d SCS nodes in Blueprint: %s"), SCSNodes.Num(), *BlueprintClass->GetName());
 
 												// Iterate over the SCS nodes to find UDynamicObject components
 												for (USCS_Node* SCSNode : SCSNodes)
@@ -711,7 +677,6 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 													if (SCSNode && SCSNode->ComponentTemplate)
 													{
 														UActorComponent* ComponentTemplate = SCSNode->ComponentTemplate;
-														UE_LOG(LogTemp, Warning, TEXT("Found SCS Component: %s in Blueprint: %s"), *ComponentTemplate->GetName(), *BlueprintClass->GetName());
 
 
 														//check if ComponentTemplate is a mesh
@@ -719,11 +684,7 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 														//verify that the mesh component is valid
 														if (MeshComponent == NULL)
 														{
-															UE_LOG(LogTemp, Warning, TEXT("backup FCognitiveEditorTools::ExportDynamicData MeshComponent is null"));
-														}
-														else
-														{
-															UE_LOG(LogTemp, Warning, TEXT("backup FCognitiveEditorTools::ExportDynamicData MeshComponent is valid"));
+															continue;
 														}
 														//if its valid, get the attached child component and log them
 														if (MeshComponent)
@@ -740,11 +701,9 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 																	UDynamicObject* DynamicObjectComponent = Cast<UDynamicObject>(ChildNode->ComponentTemplate);
 																	if (DynamicObjectComponent)
 																	{
-																		UE_LOG(LogTemp, Log, TEXT("Found DynamicObjectComponent: %s"), *DynamicObjectComponent->GetName());
 																		// Do something with the dynamic object component
 																		if (DynamicObjectComponent->MeshName == data->MeshName)
 																		{
-																			UE_LOG(LogTemp, Log, TEXT("Found DynamicObjectComponent with matching MeshName: %s"), *DynamicObjectComponent->GetName());
 																			Owner = DefaultActor;
 																			isBlueprint = true;
 																			bpMesh = MeshComponent;
@@ -768,11 +727,9 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 			//both the regular owner and the found owners were null
 			if (Owner == NULL)
 			{
-				UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::ExportDynamicObjectArray Owner (from bp) is null"));
 				continue;
 			}
 
-			//continue;
 		}
 		if (exportObjects[i]->MeshName.IsEmpty())
 		{
@@ -832,9 +789,9 @@ FProcHandle FCognitiveEditorTools::ExportDynamicObjectArray(TArray<UDynamicObjec
 		if (isBlueprint)
 		{
 			UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::ExportDynamicObjectArray isBlueprint: EXPORTING NOW"));
+			
 			//use GLTFExporter Plugin
-
-						// Create export options
+			// Create export options
 			UGLTFExportOptions* ExportOptions = NewObject<UGLTFExportOptions>();
 
 			// Set custom export settings
@@ -1258,8 +1215,6 @@ FReply FCognitiveEditorTools::SetUniqueDynamicIds()
 
 FReply FCognitiveEditorTools::UploadDynamicsManifest()
 {
-	//UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::UploadDynamicsManifest started"));
-
 	TArray<UDynamicObject*> dynamics;
 
 	//get all the dynamic objects in the scene
@@ -1267,20 +1222,16 @@ FReply FCognitiveEditorTools::UploadDynamicsManifest()
 	{
 		// Same as with the Object Iterator, access the subclass instance with the * or -> operators.
 		//AStaticMeshActor *Mesh = *ActorItr;
-		//UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::UploadDynamicsManifest found actor %s"), *ActorItr->GetName());
 		//check all compoenents on the actor in case there are multiple dynamic objects
 		for (UActorComponent* actorComponent : ActorItr->GetComponents())
 		{
-			//UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::UploadDynamicsManifest found component %s"), *actorComponent->GetName());
 			if (actorComponent->IsA(UDynamicObject::StaticClass()))
 			{
-				//UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::UploadDynamicsManifest found dynamic object"));
 				UDynamicObject* dynamic = Cast<UDynamicObject>(actorComponent);
 				if (dynamic == NULL)
 				{
 					continue;
 				}
-				//UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::UploadDynamicsManifest found dynamic object %s"), *dynamic->MeshName);
 				dynamics.Add(dynamic);
 			}
 		}
@@ -1339,22 +1290,6 @@ FReply FCognitiveEditorTools::UploadDynamicsManifest()
 
 FReply FCognitiveEditorTools::UploadSelectedDynamicsManifest(TArray<UDynamicObject*> dynamics)
 {
-	UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::UploadSelectedDynamicsManifest started"));
-	
-	UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::UploadSelectedDynamicsManifest found %d dynamics"), dynamics.Num());
-
-	for (const UDynamicObject* dynamicObject : dynamics)
-	{
-		if (dynamicObject)
-		{
-			UE_LOG(LogTemp, Log, TEXT("Dynamic Object: %s"), *dynamicObject->GetName());
-		}
-		else
-		{
-			UE_LOG(LogTemp, Warning, TEXT("Null Dynamic Object in array"));
-		}
-	}
-
 	bool wroteAnyObjects = false;
 
 	//split up dynamics and make a web request every 250 items, up to 99 calls
@@ -1390,31 +1325,22 @@ FReply FCognitiveEditorTools::UploadSelectedDynamicsManifest(TArray<UDynamicObje
 						{
 							if (Blueprint->GetName() == data->Name)
 							{
-								UE_LOG(LogTemp, Log, TEXT("Found blueprint: %s"), *Blueprint->GetName());
 								// Get the generated class from the blueprint
 								UClass* BlueprintClass = Blueprint->GeneratedClass;
 								if (BlueprintClass)
 								{
-									UE_LOG(LogTemp, Log, TEXT("Found blueprint class: %s"), *BlueprintClass->GetName());
-
 									if (BlueprintClass && BlueprintClass->IsChildOf(AActor::StaticClass()))
 									{
-										UE_LOG(LogTemp, Warning, TEXT("Found Actor-based Blueprint class: %s"), *BlueprintClass->GetName());
-
 										// Now, get the default object and access its components
 										AActor* DefaultActor = Cast<AActor>(BlueprintClass->GetDefaultObject());
 										if (DefaultActor)
 										{
-											UE_LOG(LogTemp, Warning, TEXT("Default actor is valid: %s"), *DefaultActor->GetName());
-
 											// Use Simple Construction Script to inspect the blueprint's components
 											if (UBlueprintGeneratedClass* BPGeneratedClass = Cast<UBlueprintGeneratedClass>(BlueprintClass))
 											{
-												UE_LOG(LogTemp, Warning, TEXT("Found BlueprintGeneratedClass: %s"), *BPGeneratedClass->GetName());
 												if (BPGeneratedClass->SimpleConstructionScript)
 												{
 													const TArray<USCS_Node*>& SCSNodes = BPGeneratedClass->SimpleConstructionScript->GetAllNodes();
-													UE_LOG(LogTemp, Warning, TEXT("Found %d SCS nodes in Blueprint: %s"), SCSNodes.Num(), *BlueprintClass->GetName());
 
 													// Iterate over the SCS nodes to find UDynamicObject components
 													for (USCS_Node* SCSNode : SCSNodes)
@@ -1422,27 +1348,17 @@ FReply FCognitiveEditorTools::UploadSelectedDynamicsManifest(TArray<UDynamicObje
 														if (SCSNode && SCSNode->ComponentTemplate)
 														{
 															UActorComponent* ComponentTemplate = SCSNode->ComponentTemplate;
-															UE_LOG(LogTemp, Warning, TEXT("Found SCS Component: %s in Blueprint: %s"), *ComponentTemplate->GetName(), *BlueprintClass->GetName());
 
 															//check if ComponentTemplate is a mesh
 															UMeshComponent* MeshComponent = Cast<UMeshComponent>(ComponentTemplate);
 															//verify that the mesh component is valid
 															if (MeshComponent == NULL)
 															{
-																UE_LOG(LogTemp, Warning, TEXT("backup FCognitiveEditorTools::ExportDynamicData MeshComponent is null"));
-
-															}
-															else
-															{
-																UE_LOG(LogTemp, Warning, TEXT("backup FCognitiveEditorTools::ExportDynamicData MeshComponent is valid"));
-
-																//Owner = DefaultActor;
+																continue;
 															}
 															//if its valid, get the attached child component and log them
 															if (MeshComponent)
 															{
-																//const TArray<USCS_Node*>& SCSNodes = BPGeneratedClass->SimpleConstructionScript->GetAllNodes();
-
 																// Check its child nodes
 																const TArray<USCS_Node*>& ChildNodes = SCSNode->GetChildNodes();
 																for (USCS_Node* ChildNode : ChildNodes)
@@ -1453,11 +1369,9 @@ FReply FCognitiveEditorTools::UploadSelectedDynamicsManifest(TArray<UDynamicObje
 																		UDynamicObject* DynamicObjectComponent = Cast<UDynamicObject>(ChildNode->ComponentTemplate);
 																		if (DynamicObjectComponent)
 																		{
-																			UE_LOG(LogTemp, Log, TEXT("Found DynamicObjectComponent: %s"), *DynamicObjectComponent->GetName());
 																			// Do something with the dynamic object component
 																			if (DynamicObjectComponent->MeshName == data->MeshName)
 																			{
-																				UE_LOG(LogTemp, Log, TEXT("Found DynamicObjectComponent with matching MeshName: %s"), *DynamicObjectComponent->GetName());
 																				Owner = DefaultActor;
 																				isBlueprint = true;
 																				bpMesh = MeshComponent;
@@ -2902,7 +2816,6 @@ FReply FCognitiveEditorTools::RefreshDisplayDynamicObjectsCountInScene()
 	for (const FAssetData& AssetData2 : AssetDataList)
 	{
 		FString AssetName = AssetData2.AssetName.ToString();
-		UE_LOG(LogTemp, Warning, TEXT("Processing Blueprint: %s"), *AssetName);
 
 		// Get the GeneratedClass tag from the asset data (without fully loading the asset)
 		FString GeneratedClassPath;
@@ -2914,21 +2827,16 @@ FReply FCognitiveEditorTools::RefreshDisplayDynamicObjectsCountInScene()
 			
 			if (BlueprintClass && BlueprintClass->IsChildOf(AActor::StaticClass()))
 			{
-				UE_LOG(LogTemp, Warning, TEXT("Found Actor-based Blueprint class: %s"), *BlueprintClass->GetName());
-
 				// Now, get the default object and access its components
 				AActor* DefaultActor = Cast<AActor>(BlueprintClass->GetDefaultObject());
 				if (DefaultActor)
 				{
-					UE_LOG(LogTemp, Warning, TEXT("Default actor is valid: %s"), *DefaultActor->GetName());
-
 					// Use Simple Construction Script to inspect the blueprint's components
 					if (UBlueprintGeneratedClass* BPGeneratedClass = Cast<UBlueprintGeneratedClass>(BlueprintClass))
 					{
 						if (BPGeneratedClass->SimpleConstructionScript)
 						{
 							const TArray<USCS_Node*>& SCSNodes = BPGeneratedClass->SimpleConstructionScript->GetAllNodes();
-							UE_LOG(LogTemp, Warning, TEXT("Found %d SCS nodes in Blueprint: %s"), SCSNodes.Num(), *BlueprintClass->GetName());
 
 							// Iterate over the SCS nodes to find UDynamicObject components
 							for (USCS_Node* SCSNode : SCSNodes)
@@ -2936,14 +2844,11 @@ FReply FCognitiveEditorTools::RefreshDisplayDynamicObjectsCountInScene()
 								if (SCSNode && SCSNode->ComponentTemplate)
 								{
 									UActorComponent* ComponentTemplate = SCSNode->ComponentTemplate;
-									UE_LOG(LogTemp, Warning, TEXT("Found SCS Component: %s in Blueprint: %s"), *ComponentTemplate->GetName(), *BlueprintClass->GetName());
 
 									// Check if the component is a UDynamicObject
 									UDynamicObject* DynamicObjectComponent = Cast<UDynamicObject>(ComponentTemplate);
 									if (DynamicObjectComponent)
 									{
-										UE_LOG(LogTemp, Warning, TEXT("Found UDynamicObject in blueprint SCS for asset: %s"), *AssetData2.AssetName.ToString());
-
 										// Now populate the SceneDynamics based on the ID type
 										if (DynamicObjectComponent->IdSourceType == EIdSourceType::CustomId)
 										{
@@ -2967,36 +2872,12 @@ FReply FCognitiveEditorTools::RefreshDisplayDynamicObjectsCountInScene()
 											SceneDynamics.Add(MakeShareable(new FDynamicData(DynamicObjectComponent->GetOwner()->GetName(), DynamicObjectComponent->MeshName, IdString, DynamicObjectComponent->IDPool->Ids, EDynamicTypes::DynamicIdPool)));
 										}
 									}
-									else
-									{
-										UE_LOG(LogTemp, Warning, TEXT("SCS Component %s is not a UDynamicObject in Blueprint: %s"), *ComponentTemplate->GetName(), *BlueprintClass->GetName());
-									}
-								}
-								else
-								{
-									UE_LOG(LogTemp, Warning, TEXT("SCS Node or its ComponentTemplate is null in Blueprint: %s"), *BlueprintClass->GetName());
 								}
 							}
 						}
-						else
-						{
-							UE_LOG(LogTemp, Warning, TEXT("No SimpleConstructionScript found in Blueprint: %s"), *BlueprintClass->GetName());
-						}
 					}
 				}
-				else
-				{
-					UE_LOG(LogTemp, Warning, TEXT("Default actor is null for Blueprint: %s"), *BlueprintClass->GetName());
-				}
 			}
-			else
-			{
-				UE_LOG(LogTemp, Warning, TEXT("Generated class not found or not an actor-based class for Blueprint: %s"), *AssetData2.AssetName.ToString());
-			}
-		}
-		else
-		{
-			UE_LOG(LogTemp, Warning, TEXT("GeneratedClass tag not found for Blueprint: %s"), *AssetData2.AssetName.ToString());
 		}
 	}
 
@@ -3007,7 +2888,6 @@ FReply FCognitiveEditorTools::RefreshDisplayDynamicObjectsCountInScene()
 for (const FAssetData& AssetData2 : AssetDataList)
 {
 	FString AssetName = AssetData2.AssetName.ToString();
-	UE_LOG(LogTemp, Warning, TEXT("Processing Blueprint: %s"), *AssetName);
 
 	// Force load the asset to ensure all data is available
 	UBlueprint* Blueprint = Cast<UBlueprint>(AssetData2.GetAsset());
@@ -3028,7 +2908,6 @@ for (const FAssetData& AssetData2 : AssetDataList)
 		// Ensure the blueprint is compiled
 		if (!BlueprintClass)
 		{
-			UE_LOG(LogTemp, Warning, TEXT("Compiling Blueprint: %s"), *AssetName);
 			FKismetEditorUtilities::CompileBlueprint(Blueprint);
 
 			// Try to get the GeneratedClass again after compiling
@@ -3037,36 +2916,28 @@ for (const FAssetData& AssetData2 : AssetDataList)
 
 		if (BlueprintClass && BlueprintClass->IsChildOf(AActor::StaticClass()))
 		{
-			UE_LOG(LogTemp, Warning, TEXT("Found Actor-based Blueprint class: %s"), *BlueprintClass->GetName());
-
 			// Now, get the default object and access its components
 			AActor* DefaultActor = Cast<AActor>(BlueprintClass->GetDefaultObject());
 			if (DefaultActor)
 			{
-				UE_LOG(LogTemp, Warning, TEXT("Default actor is valid: %s"), *DefaultActor->GetName());
-
 				// Use Simple Construction Script to inspect the blueprint's components
 				if (UBlueprintGeneratedClass* BPGeneratedClass = Cast<UBlueprintGeneratedClass>(BlueprintClass))
 				{
 					if (BPGeneratedClass->SimpleConstructionScript)
 					{
 						const TArray<USCS_Node*>& SCSNodes = BPGeneratedClass->SimpleConstructionScript->GetAllNodes();
-						UE_LOG(LogTemp, Warning, TEXT("Found %d SCS nodes in Blueprint: %s"), SCSNodes.Num(), *BlueprintClass->GetName());
-
+						
 						// Iterate over the SCS nodes to find UDynamicObject components
 						for (USCS_Node* SCSNode : SCSNodes)
 						{
 							if (SCSNode && SCSNode->ComponentTemplate)
 							{
 								UActorComponent* ComponentTemplate = SCSNode->ComponentTemplate;
-								UE_LOG(LogTemp, Warning, TEXT("Found SCS Component: %s in Blueprint: %s"), *ComponentTemplate->GetName(), *BlueprintClass->GetName());
-
+								
 								// Check if the component is a UDynamicObject
 								UDynamicObject* DynamicObjectComponent = Cast<UDynamicObject>(ComponentTemplate);
 								if (DynamicObjectComponent)
 								{
-									UE_LOG(LogTemp, Warning, TEXT("Found UDynamicObject in blueprint SCS for asset: %s"), *AssetData2.AssetName.ToString());
-
 									// Now populate the SceneDynamics based on the ID type
 									if (DynamicObjectComponent->IdSourceType == EIdSourceType::CustomId)
 									{
@@ -3085,36 +2956,12 @@ for (const FAssetData& AssetData2 : AssetDataList)
 										SceneDynamics.Add(MakeShareable(new FDynamicData(DynamicObjectComponent->GetOwner()->GetName(), DynamicObjectComponent->MeshName, IdString, DynamicObjectComponent->IDPool->Ids, EDynamicTypes::DynamicIdPool)));
 									}
 								}
-								else
-								{
-									UE_LOG(LogTemp, Warning, TEXT("SCS Component %s is not a UDynamicObject in Blueprint: %s"), *ComponentTemplate->GetName(), *BlueprintClass->GetName());
-								}
-							}
-							else
-							{
-								UE_LOG(LogTemp, Warning, TEXT("SCS Node or its ComponentTemplate is null in Blueprint: %s"), *BlueprintClass->GetName());
 							}
 						}
 					}
-					else
-					{
-						UE_LOG(LogTemp, Warning, TEXT("No SimpleConstructionScript found in Blueprint: %s"), *BlueprintClass->GetName());
-					}
 				}
 			}
-			else
-			{
-				UE_LOG(LogTemp, Warning, TEXT("Default actor is null for Blueprint: %s"), *BlueprintClass->GetName());
-			}
 		}
-		else
-		{
-			UE_LOG(LogTemp, Warning, TEXT("Generated class not found or not an actor-based class for Blueprint: %s"), *AssetData2.AssetName.ToString());
-		}
-	}
-	else
-	{
-		UE_LOG(LogTemp, Warning, TEXT("GeneratedClass tag not found for Blueprint: %s"), *AssetData2.AssetName.ToString());
 	}
 }
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/DynamicObjectManagerWidget.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/DynamicObjectManagerWidget.h
@@ -61,6 +61,7 @@ public:
 	//assign dynamics to objects in the scene
 	FReply AssignDynamicsToActors();
 	bool IsActorInSceneSelected() const;
+	FText AssignDynamicTooltip() const;
 
 	EVisibility GetSceneWarningVisibility() const;
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/DynamicObjectTableWidget.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/DynamicObjectTableWidget.cpp
@@ -13,7 +13,7 @@ void SDynamicObjectTableWidget::Construct(const FArguments& Args)
 			[
 				SAssignNew(TableViewWidget, SActorListView)
 				.ItemHeight(24)
-				.ListItemsSource(&FCognitiveEditorTools::GetInstance()->SceneDynamics) //The Items array is the source of this listview
+				.ListItemsSource(&FCognitiveEditorTools::GetInstance()->SceneDynamics) //The Items array is the source of this listview 
 				.OnGenerateRow(this, &SDynamicObjectTableWidget::OnGenerateRowForTable)
 				.SelectionMode(ESelectionMode::Multi)
 				.OnSelectionChanged(this, &SDynamicObjectTableWidget::OnSelectionChanged)


### PR DESCRIPTION
# Description

Add the ability to find blueprints with dynamic objects in the project and show them in the dynamic object manager window. This allows the developer to export and upload those dynamics without having to open the blueprint asset(s). 
Bug fixes like 5.4 version check on a piece of code, manifest request spam, tooltip edits. 
Added isController to dynamic manifest. 
Manifest fixes also fixed upload status checkbox in dynamic manager window. 
Adjusted assigning dynamics feature requirement to only require a developer key instead of also a scene id, for when they wanna assign dynamics before setting up a scene.

Height Task ID(s) (If applicable): T-8489, T-9534, T-9535, T-9075, T-9407

## Type of change

> Note: delete the lines that are not applicable and check the boxes (add a capital "X" in the square brackets) for the type of change.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
