### PR TITLE
add toggle for gaze hits on objects

### DIFF
--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/PlayerTracker.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/PlayerTracker.h
@@ -81,6 +81,8 @@ public:
 	UPROPERTY(EditAnywhere, Category = "Cognitive3D Analytics")
 		bool DebugDisplayGaze = false;
 
+	UPROPERTY(EditAnywhere, Category = "Cognitive3D Analytics")
+		bool RecordGazeHit = true;
 
 	float GetLastSendTime();
 	int32 GetPartNumber();


### PR DESCRIPTION
# Description

Add a toggle in the PlayerTracker component for recording gaze hits on objects.

Height Task ID(s) (If applicable): T-10790

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
