### PR TITLE
c3dconfig refactor, header includes, endplay calls, fix bp do bug

### DIFF
--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DApi/CustomEventRecorder.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DApi/CustomEventRecorder.cpp
@@ -19,7 +19,10 @@ void FCustomEventRecorder::StartSession()
 
 	FString ValueReceived;
 
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "CustomEventBatchSize", false);
+	FString C3DSettingsPath = cog->GetSettingsFilePathRuntime();
+	GConfig->LoadFile(C3DSettingsPath);
+
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "CustomEventBatchSize", false);
 	if (ValueReceived.Len() > 0)
 	{
 		int32 customEventLimit = FCString::Atoi(*ValueReceived);
@@ -29,7 +32,7 @@ void FCustomEventRecorder::StartSession()
 		}
 	}
 
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "CustomEventAutoTimer", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "CustomEventAutoTimer", false);
 	if (ValueReceived.Len() > 0)
 	{
 		int32 parsedValue = FCString::Atoi(*ValueReceived);

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DApi/FixationDataRecorder.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DApi/FixationDataRecorder.cpp
@@ -17,7 +17,10 @@ void FFixationDataRecorder::StartSession()
 
 	FString ValueReceived;
 
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "FixationBatchSize", false);
+	FString C3DSettingsPath = cog->GetSettingsFilePathRuntime();
+	GConfig->LoadFile(C3DSettingsPath);
+
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "FixationBatchSize", false);
 	if (ValueReceived.Len() > 0)
 	{
 		int32 fixationLimit = FCString::Atoi(*ValueReceived);
@@ -27,7 +30,7 @@ void FFixationDataRecorder::StartSession()
 		}
 	}
 
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "FixationAutoTimer", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "FixationAutoTimer", false);
 	if (ValueReceived.Len() > 0)
 	{
 		int32 parsedValue = FCString::Atoi(*ValueReceived);

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DApi/GazeDataRecorder.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DApi/GazeDataRecorder.cpp
@@ -18,8 +18,11 @@ void FGazeDataRecorder::StartSession()
 
 	FString ValueReceived;
 
+	FString C3DSettingsPath = cog->GetSettingsFilePathRuntime();
+	GConfig->LoadFile(C3DSettingsPath);
+
 	//gaze batch size
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "GazeBatchSize", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "GazeBatchSize", false);
 	if (ValueReceived.Len() > 0)
 	{
 		int32 sensorLimit = FCString::Atoi(*ValueReceived);

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DApi/SensorRecorder.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DApi/SensorRecorder.cpp
@@ -20,7 +20,10 @@ void FSensors::StartSession()
 
 	FString ValueReceived;
 
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "SensorDataLimit", false);
+	FString C3DSettingsPath = cog->GetSettingsFilePathRuntime();
+	GConfig->LoadFile(C3DSettingsPath);
+
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "SensorDataLimit", false);
 	if (ValueReceived.Len() > 0)
 	{
 		int32 sensorLimit = FCString::Atoi(*ValueReceived);
@@ -30,7 +33,7 @@ void FSensors::StartSession()
 		}
 	}
 
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "SensorAutoTimer", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "SensorAutoTimer", false);
 	if (ValueReceived.Len() > 0)
 	{
 		int32 parsedValue = FCString::Atoi(*ValueReceived);

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/AndroidPlugin.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/AndroidPlugin.cpp
@@ -5,6 +5,7 @@
 #include "Cognitive3D/Private/C3DUtil/Util.h"
 #include "Cognitive3D/Public/Cognitive3D.h"
 #include "Regex.h"
+#include "Analytics.h"
 #if PLATFORM_ANDROID
 #include "Android/AndroidJNI.h"
 #include "Android/AndroidApplication.h"
@@ -56,6 +57,9 @@ void UAndroidPlugin::OnSessionBegin()
         return;
     }
 
+    C3DSettingsPath = cognitive->GetSettingsFilePathRuntime();
+    GConfig->LoadFile(C3DSettingsPath);
+
     FString AppKey = "APIKEY:DATA " + cognitive->ApplicationKey;
     FString DeviceId = cognitive->GetDeviceID();
     double timeStamp = FUtil::GetTimestamp();
@@ -63,8 +67,7 @@ void UAndroidPlugin::OnSessionBegin()
     FString trackingSceneID = cognitive->CurrentTrackingSceneId;
     FString trackingSceneVersionStr = cognitive->GetCurrentSceneVersionNumber();
     int trackingSceneVersion = FCString::Atoi(*trackingSceneVersionStr);
-    FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
-    FString Gateway = FAnalytics::Get().GetConfigValueFromIni(EngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+    FString Gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
     FString gazeURL = "https://" + Gateway + "/v" + FString::FromInt(0) + "/gaze/" + cognitive->GetCurrentSceneId() + "?version=" + cognitive->GetCurrentSceneVersionNumber();
     FString eventsURL = "https://" + Gateway + "/v" + FString::FromInt(0) + "/events/" + cognitive->GetCurrentSceneId() + "?version=" + cognitive->GetCurrentSceneVersionNumber();
 
@@ -245,8 +248,7 @@ void UAndroidPlugin::OnLevelLoad(UWorld* world)
         FString trackingSceneID = cognitive->CurrentTrackingSceneId;
         FString trackingSceneVersionStr = cognitive->GetCurrentSceneVersionNumber();
         int trackingSceneVersion = FCString::Atoi(*trackingSceneVersionStr);
-        FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
-        FString Gateway = FAnalytics::Get().GetConfigValueFromIni(EngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+        FString Gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
         FString gazeURL = "https://" + Gateway + "/v" + FString::FromInt(0) + "/gaze/" + cognitive->GetCurrentSceneId() + "?version=" + cognitive->GetCurrentSceneVersionNumber();
         FString eventsURL = "https://" + Gateway + "/v" + FString::FromInt(0) + "/events/" + cognitive->GetCurrentSceneId() + "?version=" + cognitive->GetCurrentSceneVersionNumber();
 
@@ -401,8 +403,7 @@ void UAndroidPlugin::LogFileHasContent()
                         }
 
                         // Generate Event and Gaze URLs
-                        FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
-                        FString Gateway = FAnalytics::Get().GetConfigValueFromIni(EngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+                        FString Gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 
                         FString SceneID = Lines[3];
                         FString VersionNumber = Lines[4];
@@ -510,8 +511,7 @@ void UAndroidPlugin::LogFileHasContent()
             {
                 FString SceneID = PreviousSessionLines[3];
                 FString VersionNumber = PreviousSessionLines[4];
-                FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
-                FString Gateway = FAnalytics::Get().GetConfigValueFromIni(EngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+                FString Gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 
                 FString EventsURL = FString::Printf(TEXT("https://%s/v0/events/%s?version=%s"), *Gateway, *SceneID, *VersionNumber);
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/AndroidPlugin.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/AndroidPlugin.h
@@ -30,6 +30,8 @@ private:
 	UFUNCTION()
 	void OnSessionEnd();
 
+	FString C3DSettingsPath;
+
 	FString FolderPath;
 	FString FolderPathCrashLog;
 	FString CurrentFilePath;

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/HMDOrientation.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/HMDOrientation.cpp
@@ -78,6 +78,8 @@ void UHMDOrientation::OnSessionEnd()
 
 void UHMDOrientation::EndPlay(EEndPlayReason::Type EndPlayReason)
 {
+	Super::EndPlay(EndPlayReason);
+
 	auto cognitive = FAnalyticsCognitive3D::Get().GetCognitive3DProvider().Pin();
 	if (cognitive.IsValid())
 	{

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/HandElevation.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/HandElevation.cpp
@@ -73,6 +73,8 @@ void UHandElevation::OnSessionEnd()
 
 void UHandElevation::EndPlay(EEndPlayReason::Type EndPlayReason)
 {
+	Super::EndPlay(EndPlayReason);
+
 	auto cognitive = FAnalyticsCognitive3D::Get().GetCognitive3DProvider().Pin();
 	if (cognitive.IsValid())
 	{

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/Passthrough.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/Passthrough.cpp
@@ -2,6 +2,12 @@
 
 
 #include "C3DComponents/Passthrough.h"
+#include "Cognitive3D/Private/C3DApi/SensorRecorder.h"
+#include "Cognitive3D/Private/C3DApi/CustomEventRecorder.h"
+#include "Cognitive3D/Public/Cognitive3D.h"
+#include "EngineUtils.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 
 // Sets default values for this component's properties
 UPassthrough::UPassthrough()

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/PlayerTracker.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/PlayerTracker.cpp
@@ -182,7 +182,7 @@ void UPlayerTracker::TickComponent(float DeltaTime, ELevelTick TickType, FActorC
 	FRotator captureRotation = controllers[0]->PlayerCameraManager->GetCameraRotation();
 
 	bool DidHitFloor = false;
-	FVector FloorHitPosition;
+	FVector FloorHitPosition = FVector::ZeroVector;
 	if (RecordGazeHit)
 	{
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/WifiSignal.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/WifiSignal.cpp
@@ -4,6 +4,8 @@
 #include "C3DComponents/WifiSignal.h"
 #include "Cognitive3D/Private/C3DUtil/Util.h"
 #include "Cognitive3D/Public/Cognitive3D.h"
+#include "Cognitive3D/Public/Cognitive3DActor.h"
+#include "Cognitive3D/Private/C3DApi/SensorRecorder.h"
 #if PLATFORM_ANDROID
 #include "Android/AndroidJNI.h"
 #include "Android/AndroidApplication.h"

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DNetwork/Network.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DNetwork/Network.cpp
@@ -8,8 +8,15 @@
 
 FNetwork::FNetwork()
 {
-	FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
-	Gateway = FAnalytics::Get().GetConfigValueFromIni(EngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+	auto cognitive = FAnalyticsCognitive3D::Get().GetCognitive3DProvider().Pin();
+	if (!cognitive.IsValid()) {
+		return;
+	}
+
+	FString C3DSettingsPath = cognitive->GetSettingsFilePathRuntime();
+	GConfig->LoadFile(C3DSettingsPath);
+
+	Gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 	cog = FAnalyticsCognitive3D::Get().GetCognitive3DProvider().Pin();
 	Http = &FHttpModule::Get();
 	hasErrorResponse = false;

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DUtil/CognitiveLog.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DUtil/CognitiveLog.cpp
@@ -12,7 +12,16 @@ void FCognitiveLog::Init()
 {
 	ShowDebugLogs = true;
 	ShowDevLogs = false;
-	FString ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "EnableLogging", false);
+
+	auto cognitive = FAnalyticsCognitive3D::Get().GetCognitive3DProvider().Pin();
+	if (!cognitive.IsValid()) {
+		return;
+	}
+
+	FString C3DSettingsPath = cognitive->GetSettingsFilePathRuntime();
+	GConfig->LoadFile(C3DSettingsPath);
+
+	FString ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "EnableLogging", false);
 	if (ValueReceived.Len()>0 && ValueReceived == "false")
 	{
 		ShowDebugLogs = false;

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/DynamicObjectManager.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/DynamicObjectManager.cpp
@@ -27,7 +27,10 @@ void FDynamicObjectManager::OnSessionBegin()
 	MaxSnapshots = 64;
 	FString ValueReceived;
 
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "DynamicDataLimit", false);
+	FString C3DSettingsPath = cogProvider->GetSettingsFilePathRuntime();
+	GConfig->LoadFile(C3DSettingsPath);
+
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "DynamicDataLimit", false);
 	if (ValueReceived.Len() > 0)
 	{
 		int32 dynamicLimit = FCString::Atoi(*ValueReceived);
@@ -37,7 +40,7 @@ void FDynamicObjectManager::OnSessionBegin()
 		}
 	}
 
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "DynamicAutoTimer", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "DynamicAutoTimer", false);
 	if (ValueReceived.Len() > 0)
 	{
 		int32 parsedValue = FCString::Atoi(*ValueReceived);

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/LocalCache.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/LocalCache.cpp
@@ -9,7 +9,16 @@ FLocalCache::FLocalCache(FString path)
 {
 	FString ValueReceived;
 	localCacheEnabled = false;
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "EnableLocalCache", false);
+
+	auto cognitive = FAnalyticsCognitive3D::Get().GetCognitive3DProvider().Pin();
+	if (!cognitive.IsValid()) {
+		return;
+	}
+
+	FString C3DSettingsPath = cognitive->GetSettingsFilePathRuntime();
+	GConfig->LoadFile(C3DSettingsPath);
+
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "EnableLocalCache", false);
 	if (ValueReceived.Len() > 0)
 	{
 		if (ValueReceived == "True")
@@ -24,7 +33,7 @@ FLocalCache::FLocalCache(FString path)
 	}
 
 	int32 targetCacheSize = 100 * 1024 * 1024; //convert to MB
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "LocalCacheSize", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "LocalCacheSize", false);
 	if (ValueReceived.Len() > 0)
 	{
 		int32 tempSize = FCString::Atoi(*ValueReceived);

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/Cognitive3DProvider.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/Cognitive3DProvider.h
@@ -140,6 +140,8 @@
 		FString ApplicationKey = "";
 		FString AttributionKey = "";
 
+		FString GetSettingsFilePathRuntime() const;
+
 		FString GetCurrentSceneId();
 		FString GetCurrentSceneVersionNumber();
 		//if a session name has been explicitly set. otherwise will use participant name when that is set

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/Cognitive3DEditorModule.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/Cognitive3DEditorModule.cpp
@@ -55,25 +55,16 @@ void FCognitive3DEditorModule::StartupModule()
 #if WITH_EDITOR
 	// Create the Extender that will add content to the menu
 	FLevelEditorModule& LevelEditorModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>(TEXT("LevelEditor"));
-
-	FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
-	FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
 	FCognitiveEditorTools::Initialize();
 
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
-	const FString NormalizedEngineIni = GConfig->NormalizeConfigIniPath(EngineIni);
-	const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
-
-	GConfig->GetString(TEXT("Analytics"), TEXT("ApiKey"), FCognitiveEditorTools::GetInstance()->ApplicationKey, NormalizedEngineIni);
-	GConfig->GetString(TEXT("Analytics"), TEXT("AttributionKey"), FCognitiveEditorTools::GetInstance()->AttributionKey, NormalizedEngineIni);
-	GConfig->GetString(TEXT("Analytics"), TEXT("DeveloperKey"), FCognitiveEditorTools::GetInstance()->DeveloperKey, NormalizedEditorIni);
-	GConfig->GetString(TEXT("Analytics"), TEXT("ExportPath"), FCognitiveEditorTools::GetInstance()->BaseExportDirectory, NormalizedEditorIni);
-#else
-	GConfig->GetString(TEXT("Analytics"), TEXT("ApiKey"), FCognitiveEditorTools::GetInstance()->ApplicationKey, EngineIni);
-	GConfig->GetString(TEXT("Analytics"), TEXT("AttributionKey"), FCognitiveEditorTools::GetInstance()->AttributionKey, EngineIni);
-	GConfig->GetString(TEXT("Analytics"), TEXT("DeveloperKey"), FCognitiveEditorTools::GetInstance()->DeveloperKey, EditorIni);
-	GConfig->GetString(TEXT("Analytics"), TEXT("ExportPath"), FCognitiveEditorTools::GetInstance()->BaseExportDirectory, EditorIni);
-#endif // ENGINE_MAJOR_VERSION == 4
+	FString C3DSettingsPath = FCognitiveEditorTools::GetInstance()->GetSettingsFilePath();
+	GConfig->LoadFile(C3DSettingsPath);
+	GConfig->Flush(true, C3DSettingsPath);
+	GConfig->GetString(TEXT("Analytics"), TEXT("ApiKey"), FCognitiveEditorTools::GetInstance()->ApplicationKey, C3DSettingsPath);
+	GConfig->GetString(TEXT("Analytics"), TEXT("AttributionKey"), FCognitiveEditorTools::GetInstance()->AttributionKey, C3DSettingsPath);
+	GConfig->GetString(TEXT("Analytics"), TEXT("DeveloperKey"), FCognitiveEditorTools::GetInstance()->DeveloperKey, C3DSettingsPath);
+	GConfig->GetString(TEXT("Analytics"), TEXT("ExportPath"), FCognitiveEditorTools::GetInstance()->BaseExportDirectory, C3DSettingsPath);
+	GConfig->Flush(false, C3DSettingsPath);
 
 	//add actions for the dynamic object id pool asset
 	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/Cognitive3DEditorModule.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/Cognitive3DEditorModule.cpp
@@ -66,6 +66,47 @@ void FCognitive3DEditorModule::StartupModule()
 	GConfig->GetString(TEXT("Analytics"), TEXT("ExportPath"), FCognitiveEditorTools::GetInstance()->BaseExportDirectory, C3DSettingsPath);
 	GConfig->Flush(false, C3DSettingsPath);
 
+	if (FCognitiveEditorTools::GetInstance()->DeveloperKey.IsEmpty() || FCognitiveEditorTools::GetInstance()->ApplicationKey.IsEmpty()
+		|| FCognitiveEditorTools::GetInstance()->BaseExportDirectory.IsEmpty())
+	{
+		FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
+		FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
+		const FString NormalizedEngineIni = GConfig->NormalizeConfigIniPath(EngineIni);
+		const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
+
+		GConfig->GetString(TEXT("Analytics"), TEXT("ApiKey"), FCognitiveEditorTools::GetInstance()->ApplicationKey, NormalizedEngineIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("AttributionKey"), FCognitiveEditorTools::GetInstance()->AttributionKey, NormalizedEngineIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("DeveloperKey"), FCognitiveEditorTools::GetInstance()->DeveloperKey, NormalizedEditorIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("ExportPath"), FCognitiveEditorTools::GetInstance()->BaseExportDirectory, NormalizedEditorIni);
+
+		//
+		GConfig->GetString(TEXT("Analytics"), TEXT("ApiKey"), FCognitiveEditorTools::GetInstance()->ApplicationKey, GGameIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("AttributionKey"), FCognitiveEditorTools::GetInstance()->AttributionKey, GGameIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("DeveloperKey"), FCognitiveEditorTools::GetInstance()->DeveloperKey, GGameIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("ExportPath"), FCognitiveEditorTools::GetInstance()->BaseExportDirectory, GGameIni);
+
+		GConfig->Flush(false, GGameIni);
+
+		GConfig->SetString(TEXT("Analytics"), TEXT("ApiKey"), *FCognitiveEditorTools::GetInstance()->ApplicationKey, C3DSettingsPath);
+		GConfig->SetString(TEXT("Analytics"), TEXT("AttributionKey"), *FCognitiveEditorTools::GetInstance()->AttributionKey, C3DSettingsPath);
+		GConfig->SetString(TEXT("Analytics"), TEXT("DeveloperKey"), *FCognitiveEditorTools::GetInstance()->DeveloperKey, C3DSettingsPath);
+		GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, C3DSettingsPath);
+		GConfig->Flush(false, C3DSettingsPath);
+#else
+		GConfig->GetString(TEXT("Analytics"), TEXT("ApiKey"), FCognitiveEditorTools::GetInstance()->ApplicationKey, EngineIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("AttributionKey"), FCognitiveEditorTools::GetInstance()->AttributionKey, EngineIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("DeveloperKey"), FCognitiveEditorTools::GetInstance()->DeveloperKey, EditorIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("ExportPath"), FCognitiveEditorTools::GetInstance()->BaseExportDirectory, EditorIni);
+
+		GConfig->SetString(TEXT("Analytics"), TEXT("ApiKey"), *FCognitiveEditorTools::GetInstance()->ApplicationKey, C3DSettingsPath);
+		GConfig->SetString(TEXT("Analytics"), TEXT("AttributionKey"), *FCognitiveEditorTools::GetInstance()->AttributionKey, C3DSettingsPath);
+		GConfig->SetString(TEXT("Analytics"), TEXT("DeveloperKey"), *FCognitiveEditorTools::GetInstance()->DeveloperKey, C3DSettingsPath);
+		GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, C3DSettingsPath);
+		GConfig->Flush(false, C3DSettingsPath);
+#endif // ENGINE_MAJOR_VERSION == 4
+	}
+
 	//add actions for the dynamic object id pool asset
 	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
 	TSharedPtr< FDynamicIdPoolAssetActions> action = MakeShared<FDynamicIdPoolAssetActions>();

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
@@ -63,7 +63,9 @@ FCognitiveEditorTools* FCognitiveEditorTools::GetInstance()
 //GET dynamic object manifest
 FString FCognitiveEditorTools::GetDynamicObjectManifest(FString versionid)
 {
-	Gateway = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+	FString C3DSettingsPath = GetSettingsFilePath();
+
+	Gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 	if (Gateway.Len() == 0)
 	{
 		Gateway = "data.cognitive3d.com";
@@ -74,7 +76,9 @@ FString FCognitiveEditorTools::GetDynamicObjectManifest(FString versionid)
 //POST dynamic object manifest
 FString FCognitiveEditorTools::PostDynamicObjectManifest(FString sceneid, int32 versionnumber)
 {
-	Gateway = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+	FString C3DSettingsPath = GetSettingsFilePath();
+
+	Gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 	if (Gateway.Len() == 0)
 	{
 		Gateway = "data.cognitive3d.com";
@@ -85,7 +89,9 @@ FString FCognitiveEditorTools::PostDynamicObjectManifest(FString sceneid, int32 
 //POST dynamic object mesh data
 FString FCognitiveEditorTools::PostDynamicObjectMeshData(FString sceneid, int32 versionnumber, FString exportdirectory)
 {
-	Gateway = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+	FString C3DSettingsPath = GetSettingsFilePath();
+
+	Gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 	if (Gateway.Len() == 0)
 	{
 		Gateway = "data.cognitive3d.com";
@@ -96,7 +102,9 @@ FString FCognitiveEditorTools::PostDynamicObjectMeshData(FString sceneid, int32 
 //GET scene settings and read scene version
 FString FCognitiveEditorTools::GetSceneVersion(FString sceneid)
 {
-	Gateway = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+	FString C3DSettingsPath = GetSettingsFilePath();
+
+	Gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 	if (Gateway.Len() == 0)
 	{
 		Gateway = "data.cognitive3d.com";
@@ -107,7 +115,9 @@ FString FCognitiveEditorTools::GetSceneVersion(FString sceneid)
 //POST scene screenshot
 FString FCognitiveEditorTools::PostScreenshot(FString sceneid, FString versionnumber)
 {
-	Gateway = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+	FString C3DSettingsPath = GetSettingsFilePath();
+
+	Gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 	if (Gateway.Len() == 0)
 	{
 		Gateway = "data.cognitive3d.com";
@@ -118,7 +128,9 @@ FString FCognitiveEditorTools::PostScreenshot(FString sceneid, FString versionnu
 //POST upload decimated scene
 FString FCognitiveEditorTools::PostNewScene()
 {
-	Gateway = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+	FString C3DSettingsPath = GetSettingsFilePath();
+
+	Gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 	if (Gateway.Len() == 0)
 	{
 		Gateway = "data.cognitive3d.com";
@@ -129,7 +141,9 @@ FString FCognitiveEditorTools::PostNewScene()
 //POST upload and replace existing scene
 FString FCognitiveEditorTools::PostUpdateScene(FString sceneid)
 {
-	Gateway = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+	FString C3DSettingsPath = GetSettingsFilePath();
+
+	Gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 	if (Gateway.Len() == 0)
 	{
 		Gateway = "data.cognitive3d.com";
@@ -140,7 +154,9 @@ FString FCognitiveEditorTools::PostUpdateScene(FString sceneid)
 //WEB used to open scenes on sceneexplorer or custom session viewer
 FString FCognitiveEditorTools::SceneExplorerOpen(FString sceneid)
 {
-	Gateway = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+	FString C3DSettingsPath = GetSettingsFilePath();
+
+	Gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 	if (Gateway.Len() == 0)
 	{
 		Gateway = "data.cognitive3d.com";
@@ -155,8 +171,35 @@ void FCognitiveEditorTools::Initialize()
 {
 	CognitiveEditorToolsInstance = new FCognitiveEditorTools;
 
+	FString BaseConfigDir = FPaths::ProjectConfigDir();
+
+	// Define the subfolder and ensure it exists.
+	FString CustomFolder = FPaths::Combine(BaseConfigDir, TEXT("c3dlocal"));
+	if (!FPaths::DirectoryExists(CustomFolder))
+	{
+		// Create the directory if it doesn't exist.
+		IFileManager::Get().MakeDirectory(*CustomFolder);
+	}
+
+	// Combine the subfolder path with your INI file name.
+	FString ConfigFilePath = FPaths::Combine(CustomFolder, TEXT("Cognitive3DSettings.ini"));
+
+	// If the file doesn't exist, create it with some default content.
+	if (!FPaths::FileExists(ConfigFilePath))
+	{
+		FString DefaultContent = TEXT("; Cognitive3D Plugin Settings\n[General]\n");
+		if (!FFileHelper::SaveStringToFile(DefaultContent, *ConfigFilePath))
+		{
+			UE_LOG(LogTemp, Error, TEXT("Failed to create config file: %s"), *ConfigFilePath);
+			return;
+		}
+	}
+	//ConfigFilePath = FConfigCacheIni::NormalizeConfigIniPath(ConfigFilePath);
+	// Explicitly load the custom config file into GConfig.
+	GConfig->LoadFile(ConfigFilePath);
+
 	//should be able to update gateway while unreal is running, but cache if not in editor since that's nuts
-	Gateway = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+	Gateway = FAnalytics::Get().GetConfigValueFromIni(ConfigFilePath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 
 	//should update both editor urls and session data urls
 	IImageWrapperModule& ImageWrapperModule = FModuleManager::LoadModuleChecked<IImageWrapperModule>(TEXT("ImageWrapper"));
@@ -173,124 +216,76 @@ void FCognitiveEditorTools::Initialize()
 
 void FCognitiveEditorTools::CheckIniConfigured()
 {
-	GConfig->Flush(true, GEngineIni);
-	FString tempGateway;
-	GConfig->GetString(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("Gateway"), tempGateway, GEngineIni);
+	GLog->Log("FCognitiveEditorTools::CheckIniConfigured called");
+	// Get the project's Config directory.
+	FString BaseConfigDir = FPaths::ProjectConfigDir();
 
-	if (tempGateway.IsEmpty())
+	// Define the subfolder and ensure it exists.
+	FString CustomFolder = FPaths::Combine(BaseConfigDir, TEXT("c3dlocal"));
+	if (!FPaths::DirectoryExists(CustomFolder))
+	{
+		// Create the directory if it doesn't exist.
+		IFileManager::Get().MakeDirectory(*CustomFolder);
+	}
+
+	// Combine the subfolder path with your INI file name.
+	FString ConfigFilePath = FPaths::Combine(CustomFolder, TEXT("Cognitive3DSettings.ini"));
+
+	// If the file doesn't exist, create it with some default content.
+	if (!FPaths::FileExists(ConfigFilePath))
+	{
+		FString DefaultContent = TEXT("; Cognitive3D Plugin Settings\n[General]\n");
+		if (!FFileHelper::SaveStringToFile(DefaultContent, *ConfigFilePath))
+		{
+			UE_LOG(LogTemp, Error, TEXT("Failed to create config file: %s"), *ConfigFilePath);
+			return;
+		}
+	}
+	//ConfigFilePath = FConfigCacheIni::NormalizeConfigIniPath(ConfigFilePath);
+	// Explicitly load the custom config file into GConfig.
+	GConfig->LoadFile(ConfigFilePath);
+
+	GConfig->Flush(true, ConfigFilePath);
+	FString tempC3DGateway;
+	GConfig->GetString(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("Gateway"), tempC3DGateway, ConfigFilePath);
+
+	if (tempC3DGateway.IsEmpty())
 	{
 		GLog->Log("FCognitiveEditorTools::CheckIniConfigured write defaults to ini");
 		FString defaultgateway = "data.cognitive3d.com";
 		FString trueString = "True";
-		GConfig->SetString(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("Gateway"), *defaultgateway, GEngineIni);
+		GConfig->SetString(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("Gateway"), *defaultgateway, ConfigFilePath);
 
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("GazeBatchSize"), 256, GEngineIni);
+		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("GazeBatchSize"), 256, ConfigFilePath);
 
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("CustomEventBatchSize"), 256, GEngineIni);
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("CustomEventAutoTimer"), 10, GEngineIni);
+		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("CustomEventBatchSize"), 256, ConfigFilePath);
+		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("CustomEventAutoTimer"), 10, ConfigFilePath);
 
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("DynamicDataLimit"), 512, GEngineIni);
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("DynamicAutoTimer"), 10, GEngineIni);
+		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("DynamicDataLimit"), 512, ConfigFilePath);
+		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("DynamicAutoTimer"), 10, ConfigFilePath);
 
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("SensorDataLimit"), 512, GEngineIni);
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("SensorAutoTimer"), 10, GEngineIni);
+		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("SensorDataLimit"), 512, ConfigFilePath);
+		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("SensorAutoTimer"), 10, ConfigFilePath);
 
-		GConfig->SetString(TEXT("Analytics"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), GEngineIni);
-		GConfig->SetString(TEXT("AnalyticsDebug"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), GEngineIni);
-		GConfig->SetString(TEXT("AnalyticsTest"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), GEngineIni);
-		GConfig->SetString(TEXT("AnalyticsDevelopment"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), GEngineIni);
+		GConfig->SetString(TEXT("Analytics"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), ConfigFilePath);
+		GConfig->SetString(TEXT("AnalyticsDebug"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), ConfigFilePath);
+		GConfig->SetString(TEXT("AnalyticsTest"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), ConfigFilePath);
+		GConfig->SetString(TEXT("AnalyticsDevelopment"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), ConfigFilePath);
 
-		GConfig->SetString(TEXT("Analytics"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), GEngineIni);
-		GConfig->SetString(TEXT("AnalyticsDebug"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), GEngineIni);
-		GConfig->SetString(TEXT("AnalyticsTest"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), GEngineIni);
-		GConfig->SetString(TEXT("AnalyticsDevelopment"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), GEngineIni);
+		GConfig->SetString(TEXT("Analytics"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), ConfigFilePath);
+		GConfig->SetString(TEXT("AnalyticsDebug"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), ConfigFilePath);
+		GConfig->SetString(TEXT("AnalyticsTest"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), ConfigFilePath);
+		GConfig->SetString(TEXT("AnalyticsDevelopment"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), ConfigFilePath);
 
-		GConfig->SetString(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("EnableLocalCache"), *trueString, GEngineIni);
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("LocalCacheSize"), 100, GEngineIni);
-		GConfig->Flush(false, GEngineIni);
+		GConfig->SetString(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("EnableLocalCache"), *trueString, ConfigFilePath);
+		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("LocalCacheSize"), 100, ConfigFilePath);
+		GConfig->Flush(false, ConfigFilePath);
 	}
-
-	FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
-
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
-	const FString NormalizedEngineIni = GConfig->NormalizeConfigIniPath(EngineIni);
-
-	GConfig->Flush(true, NormalizedEngineIni);
-	FString tempGatewaydefault;
-	GConfig->GetString(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("Gateway"), tempGatewaydefault, NormalizedEngineIni);
-
-	if (tempGatewaydefault.IsEmpty())
+	else
 	{
-		GLog->Log("FCognitiveEditorTools::CheckIniConfigured write defaults to ini");
-		FString defaultgateway = "data.cognitive3d.com";
-		FString trueString = "True";
-		GConfig->SetString(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("Gateway"), *defaultgateway, NormalizedEngineIni);
-
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("GazeBatchSize"), 256, NormalizedEngineIni);
-
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("CustomEventBatchSize"), 256, NormalizedEngineIni);
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("CustomEventAutoTimer"), 10, NormalizedEngineIni);
-
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("DynamicDataLimit"), 512, NormalizedEngineIni);
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("DynamicAutoTimer"), 10, NormalizedEngineIni);
-
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("SensorDataLimit"), 512, NormalizedEngineIni);
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("SensorAutoTimer"), 10, NormalizedEngineIni);
-
-		GConfig->SetString(TEXT("Analytics"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), NormalizedEngineIni);
-		GConfig->SetString(TEXT("AnalyticsDebug"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), NormalizedEngineIni);
-		GConfig->SetString(TEXT("AnalyticsTest"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), NormalizedEngineIni);
-		GConfig->SetString(TEXT("AnalyticsDevelopment"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), NormalizedEngineIni);
-
-		GConfig->SetString(TEXT("Analytics"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), NormalizedEngineIni);
-		GConfig->SetString(TEXT("AnalyticsDebug"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), NormalizedEngineIni);
-		GConfig->SetString(TEXT("AnalyticsTest"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), NormalizedEngineIni);
-		GConfig->SetString(TEXT("AnalyticsDevelopment"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), NormalizedEngineIni);
-
-		GConfig->SetString(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("EnableLocalCache"), *trueString, NormalizedEngineIni);
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("LocalCacheSize"), 100, NormalizedEngineIni);
-		GConfig->Flush(false, NormalizedEngineIni);
+		UE_LOG(LogTemp, Warning, TEXT("FCognitiveEditorTools::CheckIniConfigured Gateway already set: %s"), *tempC3DGateway);
 	}
 
-#else
-
-	GConfig->Flush(true, EngineIni);
-	FString tempGatewaydefault;
-	GConfig->GetString(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("Gateway"), tempGatewaydefault, EngineIni);
-
-	if (tempGatewaydefault.IsEmpty())
-	{
-		GLog->Log("FCognitiveEditorTools::CheckIniConfigured write defaults to ini");
-		FString defaultgateway = "data.cognitive3d.com";
-		FString trueString = "True";
-		GConfig->SetString(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("Gateway"), *defaultgateway, EngineIni);
-
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("GazeBatchSize"), 256, EngineIni);
-
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("CustomEventBatchSize"), 256, EngineIni);
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("CustomEventAutoTimer"), 10, EngineIni);
-
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("DynamicDataLimit"), 512, EngineIni);
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("DynamicAutoTimer"), 10, EngineIni);
-
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("SensorDataLimit"), 512, EngineIni);
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("SensorAutoTimer"), 10, EngineIni);
-
-		GConfig->SetString(TEXT("Analytics"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), EngineIni);
-		GConfig->SetString(TEXT("AnalyticsDebug"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), EngineIni);
-		GConfig->SetString(TEXT("AnalyticsTest"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), EngineIni);
-		GConfig->SetString(TEXT("AnalyticsDevelopment"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), EngineIni);
-
-		GConfig->SetString(TEXT("Analytics"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), EngineIni);
-		GConfig->SetString(TEXT("AnalyticsDebug"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), EngineIni);
-		GConfig->SetString(TEXT("AnalyticsTest"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), EngineIni);
-		GConfig->SetString(TEXT("AnalyticsDevelopment"), TEXT("ProviderModuleName"), TEXT("Cognitive3D"), EngineIni);
-
-		GConfig->SetString(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("EnableLocalCache"), *trueString, EngineIni);
-		GConfig->SetInt(TEXT("/Script/Cognitive3D.Cognitive3DSettings"), TEXT("LocalCacheSize"), 100, EngineIni);
-		GConfig->Flush(false, EngineIni);
-	}
-#endif
 }
 
 //at any step in the uploading process
@@ -320,6 +315,36 @@ bool FCognitiveEditorTools::HasDeveloperKey() const
 bool FCognitiveEditorTools::HasApplicationKey() const
 {
 	return ApplicationKey.Len() > 0;
+}
+
+FString FCognitiveEditorTools::GetSettingsFilePath() const
+{
+	// Get the project's Config directory.
+	FString BaseConfigDir = FPaths::ProjectConfigDir();
+
+	// Define the subfolder and ensure it exists.
+	FString CustomFolder = FPaths::Combine(BaseConfigDir, TEXT("c3dlocal"));
+	if (!FPaths::DirectoryExists(CustomFolder))
+	{
+		// Create the directory if it doesn't exist.
+		IFileManager::Get().MakeDirectory(*CustomFolder);
+	}
+
+	// Combine the subfolder path with your INI file name.
+	FString ConfigFilePath = FPaths::Combine(CustomFolder, TEXT("Cognitive3DSettings.ini"));
+
+	// If the file doesn't exist, create it with some default content.
+	if (!FPaths::FileExists(ConfigFilePath))
+	{
+		FString DefaultContent = TEXT("; Cognitive3D Plugin Settings\n[General]\n");
+		if (!FFileHelper::SaveStringToFile(DefaultContent, *ConfigFilePath))
+		{
+			UE_LOG(LogTemp, Error, TEXT("Failed to create config file: %s"), *ConfigFilePath);
+			return FString();
+		}
+	}
+	//ConfigFilePath = FConfigCacheIni::NormalizeConfigIniPath(ConfigFilePath);
+	return ConfigFilePath;
 }
 
 FProcHandle FCognitiveEditorTools::ExportNewDynamics()
@@ -1962,31 +1987,20 @@ FReply FCognitiveEditorTools::SelectBaseExportDirectory()
 	if (PickDirectory(title, fileTypes, lastPath, defaultfile, outFilename))
 	{
 		BaseExportDirectory = outFilename;
-		FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
-		
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
-		const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
-		GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, NormalizedEditorIni);
-		GConfig->Flush(false, NormalizedEditorIni);
-#else
-		GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, EditorIni);
-		GConfig->Flush(false, EditorIni);
-#endif
+
+		FString C3DSettingsPath = GetSettingsFilePath();
+		GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, C3DSettingsPath);
+		GConfig->Flush(false, C3DSettingsPath);
+
 	}
 	else
 	{
 		//set default export directory if it isnt set
 		SetDefaultIfNoExportDirectory();
-		FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
+		FString C3DSettingsPath = GetSettingsFilePath();
+		GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, C3DSettingsPath);
+		GConfig->Flush(false, C3DSettingsPath);
 
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
-		const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
-		GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, NormalizedEditorIni);
-		GConfig->Flush(false, NormalizedEditorIni);
-#else
-		GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, EditorIni);
-		GConfig->Flush(false, EditorIni);
-#endif
 	}
 	return FReply::Handled();
 }
@@ -2875,7 +2889,7 @@ FReply FCognitiveEditorTools::RefreshDisplayDynamicObjectsCountInScene()
 
 	UE_LOG(LogTemp, Warning, TEXT("Total Blueprints Found: %d"), AssetDataList.Num());
 
-#if ENGINE_MAJOR_VERSION == 4
+//#if ENGINE_MAJOR_VERSION == 4
 
 	for (const FAssetData& AssetData2 : AssetDataList)
 	{
@@ -2944,8 +2958,8 @@ FReply FCognitiveEditorTools::RefreshDisplayDynamicObjectsCountInScene()
 			}
 		}
 	}
-
-#elif ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+/*
+//#elif ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
 
 //BLUEPRINTS WITH DYNAMICS
 
@@ -2954,14 +2968,14 @@ for (const FAssetData& AssetData2 : AssetDataList)
 	FString AssetName = AssetData2.AssetName.ToString();
 
 	// Force load the asset to ensure all data is available
-	/*
+	
 	UBlueprint* Blueprint = Cast<UBlueprint>(AssetData2.GetAsset());
 	if (!Blueprint)
 	{
 		UE_LOG(LogTemp, Warning, TEXT("Failed to load Blueprint: %s"), *AssetName);
 		continue;
 	}
-	*/
+	
 
 	// Get the GeneratedClass tag from the asset data (without fully loading the asset)
 	FString GeneratedClassPath;
@@ -3033,8 +3047,8 @@ for (const FAssetData& AssetData2 : AssetDataList)
 
 //BLUEPRINTS WITH DYNAMICS
 
-#endif
-
+//#endif
+*/
 
 	return FReply::Handled();
 }
@@ -3150,16 +3164,10 @@ void FCognitiveEditorTools::OnAttributionKeyChanged(const FText& Text)
 void FCognitiveEditorTools::OnExportPathChanged(const FText& Text)
 {
 	BaseExportDirectory = Text.ToString();
-	FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
 
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
-	const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
-	GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, NormalizedEditorIni);
-	GConfig->Flush(false, NormalizedEditorIni);
-#else
-	GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, EditorIni);
-	GConfig->Flush(false, EditorIni);
-#endif
+	FString C3DSettingsPath = GetSettingsFilePath();
+	GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, C3DSettingsPath);
+	GConfig->Flush(false, C3DSettingsPath);
 }
 
 FText FCognitiveEditorTools::UploadSceneNameFiles(FString LevelName) const
@@ -3339,14 +3347,28 @@ void FCognitiveEditorTools::ReadSceneDataFromFile()
 	SceneData.Empty();
 
 	TArray<FString>scenstrings;
-	FString TestSyncFile = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
+
+	FString C3DSettingsPath = GetSettingsFilePath();
+	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenstrings, C3DSettingsPath);
+	GConfig->Flush(false, C3DSettingsPath);
+
+	if (scenstrings.Num() == 0)
+	{
+		FString TestSyncFile = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
 
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
-	const FString NormalizedTestSyncFile = GConfig->NormalizeConfigIniPath(TestSyncFile);
-	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenstrings, NormalizedTestSyncFile);
+		const FString NormalizedTestSyncFile = GConfig->NormalizeConfigIniPath(TestSyncFile);
+		GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenstrings, NormalizedTestSyncFile);
+		GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenstrings, C3DSettingsPath);
+		GConfig->Flush(false, NormalizedTestSyncFile);
 #else
-	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenstrings, TestSyncFile);
+		GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenstrings, TestSyncFile);
+		GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenstrings, C3DSettingsPath);
+		GConfig->Flush(false, TestSyncFile);
 #endif
+		GConfig->Flush(false, C3DSettingsPath);
+	}
+
 	for (int32 i = 0; i < scenstrings.Num(); i++)
 	{
 		TArray<FString> Array;
@@ -3477,14 +3499,29 @@ void FCognitiveEditorTools::SceneVersionResponse(FHttpRequestPtr Request, FHttpR
 		//get array of scene data
 		TArray<FString> iniscenedata;
 
-		FString TestSyncFile = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
+		FString C3DSettingsPath = GetSettingsFilePath();
+		GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, C3DSettingsPath);
+		GConfig->Flush(false, C3DSettingsPath);
+		if (iniscenedata.Num() == 0)
+		{
+			GLog->Log("FCognitiveTools::SceneVersionResponse can't find scene data in C3D ini files");
+			WizardUploadError = "FCognitiveTools::SceneVersionResponse can't find scene data in ini files";
+
+
+			FString TestSyncFile = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
 
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
-		const FString NormalizedTestSyncFile = GConfig->NormalizeConfigIniPath(TestSyncFile);
-		GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, NormalizedTestSyncFile);
+			const FString NormalizedTestSyncFile = GConfig->NormalizeConfigIniPath(TestSyncFile);
+			GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, NormalizedTestSyncFile);
+			GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, C3DSettingsPath);
+			GConfig->Flush(false, NormalizedTestSyncFile);
 #else
-		GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, TestSyncFile);
+			GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, TestSyncFile);
+			GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, C3DSettingsPath);
+			GConfig->Flush(false, TestSyncFile);
 #endif
+			GConfig->Flush(false, C3DSettingsPath);
+		}
 		//GLog->Log("found this many scene datas in ini " + FString::FromInt(iniscenedata.Num()));
 		//GLog->Log("looking for scene " + currentSceneData->Name);
 
@@ -3513,26 +3550,11 @@ void FCognitiveEditorTools::SceneVersionResponse(FHttpRequestPtr Request, FHttpR
 
 		GLog->Log("FCognitiveTools::SceneVersionResponse successful. Write scene data to config file");
 
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
-		//set array to config
-		GConfig->RemoveKey(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), NormalizedTestSyncFile);
-		GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, NormalizedTestSyncFile);
+		GConfig->RemoveKey(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), C3DSettingsPath);
+		GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, C3DSettingsPath);
 
-		GConfig->Flush(false, NormalizedTestSyncFile);
-#else
-		//set array to config
-		GConfig->RemoveKey(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), TestSyncFile);
-		GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, TestSyncFile);
+		GConfig->Flush(false, C3DSettingsPath);
 
-		//FConfigCacheIni::LoadGlobalIniFile(GEngineIni, TEXT("Engine"));
-
-		//GConfig->RemoveKey(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), GEngineIni);
-		//GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), iniscenedata, GEngineIni);
-
-
-		GConfig->Flush(false, TestSyncFile);
-		//GConfig->LoadFile(TestSyncFile);
-#endif
 		ConfigFileHasChanged = true;
 		ReadSceneDataFromFile();
 
@@ -3560,27 +3582,12 @@ TArray<TSharedPtr<FEditorSceneData>> FCognitiveEditorTools::GetSceneData() const
 
 FReply FCognitiveEditorTools::SaveAPIDeveloperKeysToFile()
 {
-	FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
-	FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
+	FString C3DSettingsPath = GetSettingsFilePath();
+	GConfig->SetString(TEXT("Analytics"), TEXT("ApiKey"), *ApplicationKey, C3DSettingsPath);
+	GConfig->SetString(TEXT("Analytics"), TEXT("AttributionKey"), *AttributionKey, C3DSettingsPath);
+	GConfig->SetString(TEXT("Analytics"), TEXT("DeveloperKey"), *DeveloperKey, C3DSettingsPath);
+	GConfig->Flush(false, C3DSettingsPath);
 
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
-	const FString NormalizedEngineIni = GConfig->NormalizeConfigIniPath(EngineIni);
-	const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
-
-	GConfig->SetString(TEXT("Analytics"), TEXT("ApiKey"), *ApplicationKey, NormalizedEngineIni);
-	GConfig->SetString(TEXT("Analytics"), TEXT("AttributionKey"), *AttributionKey, NormalizedEngineIni);
-	GConfig->SetString(TEXT("Analytics"), TEXT("DeveloperKey"), *DeveloperKey, NormalizedEditorIni);
-
-	GConfig->Flush(false, NormalizedEngineIni);
-	GConfig->Flush(false, NormalizedEditorIni);
-#else
-	GConfig->SetString(TEXT("Analytics"), TEXT("ApiKey"), *ApplicationKey, EngineIni);
-	GConfig->SetString(TEXT("Analytics"), TEXT("AttributionKey"), *AttributionKey, EngineIni);
-	GConfig->SetString(TEXT("Analytics"), TEXT("DeveloperKey"), *DeveloperKey, EditorIni);
-
-	GConfig->Flush(false, EngineIni);
-	GConfig->Flush(false, EditorIni);
-#endif
 	ConfigFileHasChanged = true;
 
 	return FReply::Handled();
@@ -3588,17 +3595,9 @@ FReply FCognitiveEditorTools::SaveAPIDeveloperKeysToFile()
 
 void FCognitiveEditorTools::SaveApplicationKeyToFile(FString key)
 {
-	FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
-
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
-	const FString NormalizedEngineIni = GConfig->NormalizeConfigIniPath(EngineIni);
-
-	GConfig->SetString(TEXT("Analytics"), TEXT("ApiKey"), *key, NormalizedEngineIni);
-	GConfig->Flush(false, NormalizedEngineIni);
-#else
-	GConfig->SetString(TEXT("Analytics"), TEXT("ApiKey"), *key, EngineIni);
-	GConfig->Flush(false, EngineIni);
-#endif
+	FString C3DSettingsPath = GetSettingsFilePath();
+	GConfig->SetString(TEXT("Analytics"), TEXT("ApiKey"), *key, C3DSettingsPath);
+	GConfig->Flush(false, C3DSettingsPath);
 
 	ConfigFileHasChanged = true;
 
@@ -3607,17 +3606,9 @@ void FCognitiveEditorTools::SaveApplicationKeyToFile(FString key)
 
 void FCognitiveEditorTools::SaveDeveloperKeyToFile(FString key)
 {
-	FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
-
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
-	const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
-
-	GConfig->SetString(TEXT("Analytics"), TEXT("DeveloperKey"), *key, NormalizedEditorIni);
-	GConfig->Flush(false, NormalizedEditorIni);
-#else
-	GConfig->SetString(TEXT("Analytics"), TEXT("DeveloperKey"), *key, EditorIni);
-	GConfig->Flush(false, EditorIni);
-#endif
+	FString C3DSettingsPath = GetSettingsFilePath();
+	GConfig->SetString(TEXT("Analytics"), TEXT("DeveloperKey"), *key, C3DSettingsPath);
+	GConfig->Flush(false, C3DSettingsPath);
 
 	ConfigFileHasChanged = true;
 
@@ -3658,18 +3649,27 @@ void FCognitiveEditorTools::SaveSceneData(FString sceneName, FString sceneKey)
 
 	TArray<FString> scenePairs = TArray<FString>();
 
-	FString TestSyncFile = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
+	FString C3DSettingsPath = GetSettingsFilePath();
+	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenePairs, C3DSettingsPath);
+	GConfig->Flush(false, C3DSettingsPath);
+
+	if (scenePairs.Num() == 0)
+	{
+		FString TestSyncFile = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
 
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
-	const FString NormalizedTestSyncFile = GConfig->NormalizeConfigIniPath(TestSyncFile);
+		const FString NormalizedTestSyncFile = GConfig->NormalizeConfigIniPath(TestSyncFile);
 
-	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenePairs, NormalizedTestSyncFile);
-	GConfig->Flush(false, NormalizedTestSyncFile);
+		GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenePairs, NormalizedTestSyncFile);
+		GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenePairs, C3DSettingsPath);
+		GConfig->Flush(false, NormalizedTestSyncFile);
 #else
-	GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenePairs, TestSyncFile);
-	GConfig->Flush(false, TestSyncFile);
+		GConfig->GetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenePairs, TestSyncFile);
+		GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenePairs, C3DSettingsPath);
+		GConfig->Flush(false, TestSyncFile);
 #endif
-
+		GConfig->Flush(false, C3DSettingsPath);
+	}
 	bool didSetKey = false;
 	for (int32 i = 0; i < scenePairs.Num(); i++)
 	{
@@ -3701,15 +3701,8 @@ void FCognitiveEditorTools::SaveSceneData(FString sceneName, FString sceneKey)
 		}
 	}
 
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
-	GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenePairs, NormalizedTestSyncFile);
-
-	GConfig->Flush(false, NormalizedTestSyncFile);
-#else
-	GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenePairs, TestSyncFile);
-
-	GConfig->Flush(false, TestSyncFile);
-#endif
+	GConfig->SetArray(TEXT("/Script/Cognitive3D.Cognitive3DSceneSettings"), TEXT("SceneData"), scenePairs, C3DSettingsPath);
+	GConfig->Flush(false, C3DSettingsPath);
 }
 
 
@@ -4272,13 +4265,15 @@ FString FCognitiveEditorTools::BuildDebugFileContents() const
 		outputString += FString("Plugins: PicoMobile");
 		outputString += "\n";
 	}
+	
+	FString C3DSettingsPath = GetSettingsFilePath();
 
 	//project directory
 	outputString += FString("Project Name: ") + FPaths::ProjectDir();
 	outputString += "\n";
 
 	//gateway
-	FString gateway = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+	FString gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 	outputString += "Gateway: " + gateway;
 	outputString += "\n";
 
@@ -4293,59 +4288,59 @@ FString FCognitiveEditorTools::BuildDebugFileContents() const
 	outputString += "\n";
 
 	//config settings (batch sizes, etc)
-	FString ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "CustomEventBatchSize", false);
+	FString ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "CustomEventBatchSize", false);
 	outputString += "Event Snapshot Batch Size: " + ValueReceived;
 	outputString += "\n";
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "CustomEventExtremeLimit", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "CustomEventExtremeLimit", false);
 	outputString += "Event Extreme Batch Size: " + ValueReceived;
 	outputString += "\n";
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "CustomEventMinTimer", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "CustomEventMinTimer", false);
 	outputString += "Event Minimum Send Timer: " + ValueReceived;
 	outputString += "\n";
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "CustomEventAutoTimer", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "CustomEventAutoTimer", false);
 	outputString += "Event Auto Send Timer: " + ValueReceived;
 	outputString += "\n";
 
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "SensorBatchSize", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "SensorBatchSize", false);
 	outputString += "Sensor Snapshot Batch Size: " + ValueReceived;
 	outputString += "\n";
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "SensorExtremeLimit", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "SensorExtremeLimit", false);
 	outputString += "Sensor Extreme Batch Size: " + ValueReceived;
 	outputString += "\n";
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "SensorMinTimer", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "SensorMinTimer", false);
 	outputString += "Sensor Minimum Send Timer: " + ValueReceived;
 	outputString += "\n";
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "SensorAutoTimer", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "SensorAutoTimer", false);
 	outputString += "Sensor Auto Send Timer: " + ValueReceived;
 	outputString += "\n";
 
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "DynamicBatchSize", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "DynamicBatchSize", false);
 	outputString += "Dynamic Snapshot Batch Size: " + ValueReceived;
 	outputString += "\n";
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "DynamicExtremeLimit", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "DynamicExtremeLimit", false);
 	outputString += "Dynamic Extreme Batch Size: " + ValueReceived;
 	outputString += "\n";
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "DynamicMinTimer", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "DynamicMinTimer", false);
 	outputString += "Dynamic Minimum Send Timer: " + ValueReceived;
 	outputString += "\n";
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "DynamicAutoTimer", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "DynamicAutoTimer", false);
 	outputString += "Dynamic Auto Send Timer: " + ValueReceived;
 	outputString += "\n";
 
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "GazeBatchSize", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "GazeBatchSize", false);
 	outputString += "Gaze Snapshot Batch Size: " + ValueReceived;
 	outputString += "\n";
 
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "FixationBatchSize", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "FixationBatchSize", false);
 	outputString += "Fixation Snapshot Batch Size: " + ValueReceived;
 	outputString += "\n";
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "FixationExtremeLimit", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "FixationExtremeLimit", false);
 	outputString += "Fixation Extreme Batch Size: " + ValueReceived;
 	outputString += "\n";
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "FixationMinTimer", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "FixationMinTimer", false);
 	outputString += "Fixation Minimum Send Timer: " + ValueReceived;
 	outputString += "\n";
-	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "FixationAutoTimer", false);
+	ValueReceived = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "FixationAutoTimer", false);
 	outputString += "Fixation Auto Send Timer: " + ValueReceived;
 	outputString += "\n";
 

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.h
@@ -342,7 +342,7 @@ public:
 	bool HasDeveloperKey() const;
 	bool HasApplicationKey() const;
 
-
+	FString GetSettingsFilePath() const;
 
 	//send a http request to get the scene version data for current scene from sceneexplorer
 	FReply ButtonCurrentSceneVersionRequest();

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveSettingsCustomization.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveSettingsCustomization.cpp
@@ -230,22 +230,54 @@ void ICognitiveSettingsCustomization::CustomizeDetails(IDetailLayoutBuilder& Det
 	FCognitiveEditorTools::GetInstance()->RefreshDisplayDynamicObjectsCountInScene();
 	FCognitiveEditorTools::GetInstance()->CurrentSceneVersionRequest();
 
-	FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
-	FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
+	FString C3DSettingsPath = FCognitiveEditorTools::GetInstance()->GetSettingsFilePath();
+	// Explicitly load the custom config file into GConfig.
+	GConfig->LoadFile(C3DSettingsPath);
+	GConfig->GetString(TEXT("Analytics"), TEXT("AttributionKey"), FCognitiveEditorTools::GetInstance()->AttributionKey, C3DSettingsPath);
+	GConfig->GetString(TEXT("Analytics"), TEXT("ApiKey"), FCognitiveEditorTools::GetInstance()->ApplicationKey, C3DSettingsPath);
+	GConfig->GetString(TEXT("Analytics"), TEXT("DeveloperKey"), FCognitiveEditorTools::GetInstance()->DeveloperKey, C3DSettingsPath);
 
+	GConfig->Flush(false, C3DSettingsPath);
+
+	if (FCognitiveEditorTools::GetInstance()->DeveloperKey.IsEmpty() || FCognitiveEditorTools::GetInstance()->ApplicationKey.IsEmpty())
+	{
+		FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
+		FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
-	const FString NormalizedEngineIni = GConfig->NormalizeConfigIniPath(EngineIni);
-	const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
+		const FString NormalizedEngineIni = GConfig->NormalizeConfigIniPath(EngineIni);
+		const FString NormalizedEditorIni = GConfig->NormalizeConfigIniPath(EditorIni);
 
-	GConfig->GetString(TEXT("Analytics"), TEXT("AttributionKey"), FCognitiveEditorTools::GetInstance()->AttributionKey, NormalizedEngineIni);
-	GConfig->GetString(TEXT("Analytics"), TEXT("ApiKey"), FCognitiveEditorTools::GetInstance()->ApplicationKey, NormalizedEngineIni);
-	GConfig->GetString(TEXT("Analytics"), TEXT("DeveloperKey"), FCognitiveEditorTools::GetInstance()->DeveloperKey, NormalizedEditorIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("ApiKey"), FCognitiveEditorTools::GetInstance()->ApplicationKey, NormalizedEngineIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("AttributionKey"), FCognitiveEditorTools::GetInstance()->AttributionKey, NormalizedEngineIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("DeveloperKey"), FCognitiveEditorTools::GetInstance()->DeveloperKey, NormalizedEditorIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("ExportPath"), FCognitiveEditorTools::GetInstance()->BaseExportDirectory, NormalizedEditorIni);
+
+		//
+		GConfig->GetString(TEXT("Analytics"), TEXT("ApiKey"), FCognitiveEditorTools::GetInstance()->ApplicationKey, GGameIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("AttributionKey"), FCognitiveEditorTools::GetInstance()->AttributionKey, GGameIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("DeveloperKey"), FCognitiveEditorTools::GetInstance()->DeveloperKey, GGameIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("ExportPath"), FCognitiveEditorTools::GetInstance()->BaseExportDirectory, GGameIni);
+
+		GConfig->Flush(false, GGameIni);
+
+		GConfig->SetString(TEXT("Analytics"), TEXT("ApiKey"), *FCognitiveEditorTools::GetInstance()->ApplicationKey, C3DSettingsPath);
+		GConfig->SetString(TEXT("Analytics"), TEXT("AttributionKey"), *FCognitiveEditorTools::GetInstance()->AttributionKey, C3DSettingsPath);
+		GConfig->SetString(TEXT("Analytics"), TEXT("DeveloperKey"), *FCognitiveEditorTools::GetInstance()->DeveloperKey, C3DSettingsPath);
+		GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, C3DSettingsPath);
+		GConfig->Flush(false, C3DSettingsPath);
 #else
-	GConfig->GetString(TEXT("Analytics"), TEXT("AttributionKey"), FCognitiveEditorTools::GetInstance()->AttributionKey, EngineIni);
-	GConfig->GetString(TEXT("Analytics"), TEXT("ApiKey"), FCognitiveEditorTools::GetInstance()->ApplicationKey, EngineIni);
-	GConfig->GetString(TEXT("Analytics"), TEXT("DeveloperKey"), FCognitiveEditorTools::GetInstance()->DeveloperKey, EditorIni);
-#endif
+		GConfig->GetString(TEXT("Analytics"), TEXT("ApiKey"), FCognitiveEditorTools::GetInstance()->ApplicationKey, EngineIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("AttributionKey"), FCognitiveEditorTools::GetInstance()->AttributionKey, EngineIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("DeveloperKey"), FCognitiveEditorTools::GetInstance()->DeveloperKey, EditorIni);
+		GConfig->GetString(TEXT("Analytics"), TEXT("ExportPath"), FCognitiveEditorTools::GetInstance()->BaseExportDirectory, EditorIni);
 
+		GConfig->SetString(TEXT("Analytics"), TEXT("ApiKey"), *FCognitiveEditorTools::GetInstance()->ApplicationKey, C3DSettingsPath);
+		GConfig->SetString(TEXT("Analytics"), TEXT("AttributionKey"), *FCognitiveEditorTools::GetInstance()->AttributionKey, C3DSettingsPath);
+		GConfig->SetString(TEXT("Analytics"), TEXT("DeveloperKey"), *FCognitiveEditorTools::GetInstance()->DeveloperKey, C3DSettingsPath);
+		GConfig->SetString(TEXT("Analytics"), TEXT("ExportPath"), *FCognitiveEditorTools::GetInstance()->BaseExportDirectory, C3DSettingsPath);
+		GConfig->Flush(false, C3DSettingsPath);
+#endif // ENGINE_MAJOR_VERSION == 4
+	}
 
 	//section to check third party SDKs active in the runtime build.cs file
 	IDetailCategoryBuilder& ThirdPartyData = DetailBuilder.EditCategory(TEXT("Active third party SDKs"));

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveSettingsCustomization.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveSettingsCustomization.cpp
@@ -239,7 +239,8 @@ void ICognitiveSettingsCustomization::CustomizeDetails(IDetailLayoutBuilder& Det
 
 	GConfig->Flush(false, C3DSettingsPath);
 
-	if (FCognitiveEditorTools::GetInstance()->DeveloperKey.IsEmpty() || FCognitiveEditorTools::GetInstance()->ApplicationKey.IsEmpty())
+	if (FCognitiveEditorTools::GetInstance()->DeveloperKey.IsEmpty() || FCognitiveEditorTools::GetInstance()->ApplicationKey.IsEmpty()
+		|| FCognitiveEditorTools::GetInstance()->BaseExportDirectory.IsEmpty())
 	{
 		FString EngineIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEngine.ini"));
 		FString EditorIni = FPaths::Combine(*(FPaths::ProjectDir()), TEXT("Config/DefaultEditor.ini"));

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/DynamicObjectManagerWidget.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/DynamicObjectManagerWidget.cpp
@@ -19,10 +19,11 @@ void SDynamicObjectManagerWidget::CheckForExpiredDeveloperKey()
 {
 	if (FCognitiveEditorTools::GetInstance()->HasDeveloperKey())
 	{
-		GConfig->Flush(true, GEngineIni);
+		FString C3DSettingsPath = FCognitiveEditorTools::GetInstance()->GetSettingsFilePath();
+		GConfig->Flush(true, C3DSettingsPath);
 		auto Request = FHttpModule::Get().CreateRequest();
 		Request->OnProcessRequestComplete().BindRaw(this, &SDynamicObjectManagerWidget::OnDeveloperKeyResponseReceived);
-		FString gateway = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+		FString gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 		FString url = "https://" + gateway + "/v0/apiKeys/verify";
 		Request->SetURL(url);
 		Request->SetVerb("GET");
@@ -76,7 +77,8 @@ void SDynamicObjectManagerWidget::GetDashboardManifest()
 
 		auto Request = FHttpModule::Get().CreateRequest();
 		Request->OnProcessRequestComplete().BindRaw(this, &SDynamicObjectManagerWidget::OnDashboardManifestResponseReceived);
-		FString gateway = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+		FString C3DSettingsPath = FCognitiveEditorTools::GetInstance()->GetSettingsFilePath();
+		FString gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 		FString versionid = FString::FromInt(currentSceneData->VersionId);
 		FString url = "https://" + gateway + "/v0/versions/"+versionid+"/objects";
 		Request->SetURL(url);

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/ProjectSetupWidget.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/ProjectSetupWidget.cpp
@@ -12,10 +12,11 @@
 
 void SProjectSetupWidget::CheckForExpiredDeveloperKey(FString developerKey)
 {
-	GConfig->Flush(true, GEngineIni);
+	FString C3DSettingsPath = FCognitiveEditorTools::GetInstance()->GetSettingsFilePath();
+	GConfig->Flush(true, C3DSettingsPath);
 	auto Request = FHttpModule::Get().CreateRequest();
 	Request->OnProcessRequestComplete().BindRaw(this, &SProjectSetupWidget::OnDeveloperKeyResponseReceived);
-	FString gateway = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+	FString gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 	FString url = "https://" + gateway + "/v0/apiKeys/verify";
 	Request->SetURL(url);
 	Request->SetVerb("GET");
@@ -48,7 +49,8 @@ void SProjectSetupWidget::FetchApplicationKey(FString developerKey)
 {
 	auto HttpRequest = FHttpModule::Get().CreateRequest();
 
-	FString Gateway = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+	FString C3DSettingsPath = FCognitiveEditorTools::GetInstance()->GetSettingsFilePath();
+	FString Gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 
 	FString url = FString("https://" + Gateway + "/v0/applicationKey");
 	HttpRequest->SetURL(url);
@@ -96,7 +98,8 @@ void SProjectSetupWidget::FetchOrganizationDetails(FString developerKey)
 {
 	auto HttpRequest = FHttpModule::Get().CreateRequest();
 
-	FString Gateway = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+	FString C3DSettingsPath = FCognitiveEditorTools::GetInstance()->GetSettingsFilePath();
+	FString Gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 
 	FString url = FString("https://" + Gateway + "/v0/subscriptions");
 	HttpRequest->SetURL(url);

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/SceneSetupWidget.cpp
@@ -28,10 +28,11 @@ void SSceneSetupWidget::CheckForExpiredDeveloperKey()
 {
 	if (FCognitiveEditorTools::GetInstance()->HasDeveloperKey())
 	{
-		GConfig->Flush(true, GEngineIni);
+		FString C3DSettingsPath = FCognitiveEditorTools::GetInstance()->GetSettingsFilePath();
+		GConfig->Flush(true, C3DSettingsPath);
 		auto Request = FHttpModule::Get().CreateRequest();
 		Request->OnProcessRequestComplete().BindRaw(this, &SSceneSetupWidget::OnDeveloperKeyResponseReceived);
-		FString gateway = FAnalytics::Get().GetConfigValueFromIni(GEngineIni, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
+		FString gateway = FAnalytics::Get().GetConfigValueFromIni(C3DSettingsPath, "/Script/Cognitive3D.Cognitive3DSettings", "Gateway", false);
 		FString url = "https://" + gateway + "/v0/apiKeys/verify";
 		Request->SetURL(url);
 		Request->SetVerb("GET");


### PR DESCRIPTION
# Description

Refactored the configuration system to now use a custom .ini config file inside Project/Config/c3dlocal alongside the cache files. This is to avoid using the default ini files for writing and reading settings related to our SDK specifically. This is backwards compatible and will read existing scene and key data from default ini files if available. Therefore not a breaking change.
Added header includes where missing due to 5.5 compiler errors.
Edited the blueprint dynamics code to completely remove problematic section.
Added some Super::EndPlay calls to components to prevent crash on exit.

Height Task ID(s) (If applicable): T-11215, T-11216

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
