### PR TITLE
adjusting export for landscape streaming proxy (world partition)

### DIFF
--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Cognitive3DEditor.Build.cs
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Cognitive3DEditor.Build.cs
@@ -37,7 +37,8 @@ public class Cognitive3DEditor : ModuleRules
                 "EditorScriptingUtilities",
                 "MeshUtilities",
                 "GLTFExporter",
-                "AssetRegistry"
+                "AssetRegistry",
+                "Landscape"
             });
 
         PrivateDependencyModuleNames.AddRange(

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/CognitiveEditorTools.cpp
@@ -46,6 +46,7 @@
 #include "Engine/SCS_Node.h"
 #include "Engine/BlueprintGeneratedClass.h"
 
+#include "LandscapeStreamingProxy.h"
 
 #define LOCTEXT_NAMESPACE "BaseToolEditor"
 
@@ -3858,7 +3859,19 @@ void FCognitiveEditorTools::ExportScene(FString LevelName, TArray<AActor*> actor
 
 	for (int32 i = 0; i < actorsToExport.Num(); i++)
 	{
-		GEditor->SelectActor((actorsToExport[i]), true, false, true);
+		if (ALandscapeStreamingProxy* LandscapeProxy = Cast<ALandscapeStreamingProxy>(actorsToExport[i]))
+		{
+			UE_LOG(LogTemp, Warning, TEXT("FOUND LANDSCAPE PROXY, SKIPPING SELECT"));
+		}
+		else if (actorsToExport[i]->GetName().StartsWith("SkySphereBlueprint"))
+		{
+			UE_LOG(LogTemp, Warning, TEXT("FOUND SKYSPHERE, SKIPPING SELECT"));
+		}
+		else
+		{
+			UE_LOG(LogTemp, Warning, TEXT("NOT PROXY, FOUND ACTOR: %s"), *actorsToExport[i]->GetFName().ToString());
+			GEditor->SelectActor((actorsToExport[i]), true, false, true);
+		}
 	}
 
 	//create directory at scene name path


### PR DESCRIPTION
# Description

Adjustment to exporting Landscape Streaming Proxy actors when using World Partition terrains. This ignores the proxy actors and finds instead exports the HLOD's associated with the partitions, giving us a usable heightmap in the gltf to represent the terrain on scene explorer. Also an attempt to export skyboxes (might remove before merge)

Height Task ID(s) (If applicable): T-10763

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
