### PR TITLE
Open world fixes

### DIFF
--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Cognitive3D.Build.cs
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Cognitive3D.Build.cs
@@ -67,6 +67,11 @@ namespace UnrealBuildTool.Rules
                 }
 				);
 
+            if (Target.bBuildEditor)
+            {
+                PrivateDependencyModuleNames.Add("UnrealEd");
+            }
+
             if (Target.Platform == UnrealTargetPlatform.Android)
             {
                 PublicDependencyModuleNames.AddRange(new string[]{"AndroidPermission", // Common for Android builds

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Cognitive3D.Build.cs
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Cognitive3D.Build.cs
@@ -62,8 +62,9 @@ namespace UnrealBuildTool.Rules
                     "HeadMountedDisplay",
                     "EyeTracker",
 					"EnhancedInput",
-					"InputCore"
-				}
+					"InputCore",
+                    "Landscape"
+                }
 				);
 
             if (Target.Platform == UnrealTargetPlatform.Android)

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/Cognitive3D.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/Cognitive3D.cpp
@@ -50,6 +50,7 @@
 #include "Cognitive3D/Private/C3DApi/FixationDataRecorder.h"
 #include "Cognitive3D/Private/C3DComponents/RemoteControls.h"
 #include "Cognitive3D/Private/C3DApi/RemoteControlsRecorder.h"
+#include "LandscapeStreamingProxy.h"
 
 IMPLEMENT_MODULE(FAnalyticsCognitive3D, Cognitive3D);
 
@@ -93,6 +94,31 @@ void FAnalyticsProviderCognitive3D::HandleSublevelLoaded(ULevel* level, UWorld* 
 	FString levelName = level->GetFullGroupName(true);
 	//GLog->Log("FAnalyticsProviderCognitive3D::HandleSublevelUnloaded Loaded sublevel: " + levelName);
 	auto currentSceneData = GetCurrentSceneData();
+
+	bool bIsLandscapeStreamingProxy = false;
+
+	// Check if the level has any actors and if the first valid actor is a Landscape Streaming Proxy
+	for (AActor* Actor : level->Actors)
+	{
+		if (Actor) // Make sure the actor is valid
+		{
+			if (Actor->IsA(ALandscapeStreamingProxy::StaticClass()))
+			{
+				UE_LOG(LogTemp, Log, TEXT("HandleSublevelLoaded: Detected Landscape Streaming Proxy: %s in sublevel %s"), *Actor->GetName(), *level->GetName());
+				//customEventRecorder->Send("c3d.LandscapeLoaded LOADED LANDSCAPE PROXY");
+				bIsLandscapeStreamingProxy = true;
+			}
+			else
+			{
+				UE_LOG(LogTemp, Log, TEXT("HandleSublevelLoaded: Non-landscape actor detected: %s in sublevel %s"), *Actor->GetName(), *level->GetName());
+			}
+		}
+	}
+
+	if (bIsLandscapeStreamingProxy)
+	{
+		return;
+	}
 
 	//lookup scenedata and if valid, push to the stack
 	TSharedPtr<FSceneData> data = GetSceneData(levelName);

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/Cognitive3DActor.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/Cognitive3DActor.h
@@ -42,6 +42,10 @@ private:
 	virtual void BeginPlay() override;
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
+	void OnEndPIE(bool bIsSimulating);
+
+	bool bIsEditorStoppingPIE = false;
+
 	//Find and automatically assign dynamic objects to controllers
 	UPROPERTY()
 	class UMotionControllerComponent* LeftController;


### PR DESCRIPTION
# Description

Fixing bugs related to open-world streaming levels in unreal.
Fixed end-session not triggering correctly in editor
Fixed SceneLoaded event spam when loading landscape streaming proxy actors

Height Task ID(s) (If applicable): T-11440, T-11442

## Type of change

> Note: delete the lines that are not applicable and check the boxes (add a capital "X" in the square brackets) for the type of change.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
