### PR TITLE
added fix for non-english timestamp with comma, update version number 1.12.1 patch

### DIFF
--- a/Cognitive3DTest/Plugins/Cognitive3D/Cognitive3D.uplugin
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Cognitive3D.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.12.0",
+	"VersionName": "1.12.1",
 	"FriendlyName": "Cognitive3D Analytics",
 	"Description": "Cognitive3D Analytics for Unreal",
 	"Category": "Analytics",

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/AndroidPlugin.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Private/C3DComponents/AndroidPlugin.cpp
@@ -517,7 +517,13 @@ void UAndroidPlugin::LogFileHasContent()
                 {
                     jstring JSessionID = Env->NewStringUTF(TCHAR_TO_UTF8(*PreviousSessionLines[0]));
                     jstring JUserID = Env->NewStringUTF(TCHAR_TO_UTF8(*PreviousSessionLines[1]));
-                    jstring JTimestamp = Env->NewStringUTF(TCHAR_TO_UTF8(*PreviousSessionLines[2]));
+                    //check if timestamp has comma and replace it with a period
+					FString Timestamp = PreviousSessionLines[2];
+					if (Timestamp.Contains(TEXT(",")))
+					{
+						Timestamp = Timestamp.Replace(TEXT(","), TEXT("."));
+					}
+                    jstring JTimestamp = Env->NewStringUTF(TCHAR_TO_UTF8(*Timestamp));
                     jstring JEventURL = Env->NewStringUTF(TCHAR_TO_UTF8(*EventsURL));
 
                     Env->CallVoidMethod(PluginInstance, SendEndSessionEventsMethod, JSessionID, JUserID, JTimestamp, JEventURL);

--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/Cognitive3D.h
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3D/Public/Cognitive3D.h
@@ -14,7 +14,7 @@
 DEFINE_LOG_CATEGORY_STATIC(Cognitive3D_Log, Log, All);
 
 #define Cognitive3D_SDK_NAME "unreal"
-#define Cognitive3D_SDK_VERSION "1.12.0"
+#define Cognitive3D_SDK_VERSION "1.12.1"
 
 class IAnalyticsProvider;
 class FAnalyticsProviderCognitive3D;


### PR DESCRIPTION
# Description

Adding a fix for when the timestamp has a non-standard format with a comma instead of a period, replacing it before sending the timestamp to the Android Plugin for parsing the end-session.

Height Task ID(s) (If applicable):

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
