### PR TITLE
Fix for Unreal 5.6 SavePackageArgs change

### DIFF
--- a/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/FeatureBuilderWidget.cpp
+++ b/Cognitive3DTest/Plugins/Cognitive3D/Source/Cognitive3DEditor/Private/FeatureBuilderWidget.cpp
@@ -28,6 +28,9 @@
 #include "CognitiveEditorTools.h"
 #include "Cognitive3D/Private/C3DComponents/Media.h"
 #include "Toolkits/IToolkitHost.h"
+#if ENGINE_MAJOR_VERSION == 5
+#include "UObject/SavePackage.h"
+#endif
 
 BEGIN_SLATE_FUNCTION_BUILD_OPTIMIZATION
 void SFeatureBuilderWidget::Construct(const FArguments& InArgs)
@@ -483,6 +486,18 @@ FReply SFeatureBuilderWidget::OnAddExitPollBlueprint()
 				ULevel* CurrentLevel = EditorWorld->GetCurrentLevel();
 				UPackage* LevelPackage = CurrentLevel->GetOutermost();
 				FString LevelFilename = FPackageName::LongPackageNameToFilename(LevelPackage->GetName(), FPackageName::GetMapPackageExtension());
+				
+#if ENGINE_MAJOR_VERSION == 5
+
+				FSavePackageArgs SaveArgs;
+				SaveArgs.TopLevelFlags = RF_Standalone;
+				SaveArgs.Error = GError;
+				SaveArgs.bWarnOfLongFilename = true;
+				SaveArgs.bForceByteSwapping = true;
+				SaveArgs.SaveFlags = SAVE_None;
+
+				bool bLevelSaved = UPackage::SavePackage(LevelPackage, nullptr, *LevelFilename, SaveArgs);
+#elif ENGINE_MAJOR_VERSION == 4
 				bool bLevelSaved = UPackage::SavePackage(
 					LevelPackage,
 					nullptr,
@@ -494,6 +509,7 @@ FReply SFeatureBuilderWidget::OnAddExitPollBlueprint()
 					true,
 					SAVE_None
 				);
+#endif
 				if (bLevelSaved)
 				{
 					UE_LOG(LogTemp, Log, TEXT("Level auto-saved: %s"), *LevelFilename);
@@ -535,6 +551,16 @@ FReply SFeatureBuilderWidget::OnAddRemoteControlsComponent()
 				// Now save the blueprint asset automatically
 				UPackage* Package = BP->GetOutermost();
 				FString PackageFileName = FPackageName::LongPackageNameToFilename(Package->GetName(), FPackageName::GetAssetPackageExtension());
+#if ENGINE_MAJOR_VERSION == 5
+				FSavePackageArgs SavePackageArgs;
+				SavePackageArgs.TopLevelFlags = RF_Standalone;
+				SavePackageArgs.Error = GError;
+				SavePackageArgs.bWarnOfLongFilename = true;
+				SavePackageArgs.bForceByteSwapping = true;
+				SavePackageArgs.SaveFlags = SAVE_None;
+
+				bool bSaved = UPackage::SavePackage(Package, BP, *PackageFileName, SavePackageArgs);
+#elif ENGINE_MAJOR_VERSION == 4
 				bool bSaved = UPackage::SavePackage(
 					Package,
 					BP,
@@ -546,6 +572,7 @@ FReply SFeatureBuilderWidget::OnAddRemoteControlsComponent()
 					true,
 					SAVE_None
 				);
+#endif
 				if (bSaved)
 				{
 					UE_LOG(LogTemp, Log, TEXT("Blueprint auto-saved: %s"), *PackageFileName);
@@ -561,6 +588,17 @@ FReply SFeatureBuilderWidget::OnAddRemoteControlsComponent()
 						ULevel* CurrentLevel = EditorWorld->GetCurrentLevel();
 						UPackage* LevelPackage = CurrentLevel->GetOutermost();
 						FString LevelFilename = FPackageName::LongPackageNameToFilename(LevelPackage->GetName(), FPackageName::GetMapPackageExtension());
+#if ENGINE_MAJOR_VERSION == 5
+
+						FSavePackageArgs SaveArgs;
+						SaveArgs.TopLevelFlags = RF_Standalone;
+						SaveArgs.Error = GError;
+						SaveArgs.bWarnOfLongFilename = true;
+						SaveArgs.bForceByteSwapping = true;
+						SaveArgs.SaveFlags = SAVE_None;
+
+						bool bLevelSaved = UPackage::SavePackage(LevelPackage, nullptr, *LevelFilename, SaveArgs);
+#elif ENGINE_MAJOR_VERSION == 4
 						bool bLevelSaved = UPackage::SavePackage(
 							LevelPackage,
 							nullptr,
@@ -572,6 +610,7 @@ FReply SFeatureBuilderWidget::OnAddRemoteControlsComponent()
 							true,
 							SAVE_None
 						);
+#endif
 						if (bLevelSaved)
 						{
 							UE_LOG(LogTemp, Log, TEXT("Level auto-saved: %s"), *LevelFilename);
@@ -672,7 +711,28 @@ FReply SFeatureBuilderWidget::OnToggleRemoteControlsComponent()
 						// Save and compile the blueprint
 						UPackage* Package = BP->GetOutermost();
 						FString PackageFileName = FPackageName::LongPackageNameToFilename(Package->GetName(), FPackageName::GetAssetPackageExtension());
-						bool bSaved = UPackage::SavePackage(Package, BP, RF_Standalone, *PackageFileName, GError, nullptr, true, true, SAVE_None);
+#if ENGINE_MAJOR_VERSION == 5
+						FSavePackageArgs SavePackageArgs;
+						SavePackageArgs.TopLevelFlags = RF_Standalone;
+						SavePackageArgs.Error = GError;
+						SavePackageArgs.bWarnOfLongFilename = true;
+						SavePackageArgs.bForceByteSwapping = true;
+						SavePackageArgs.SaveFlags = SAVE_None;
+
+						bool bSaved = UPackage::SavePackage(Package, BP, *PackageFileName, SavePackageArgs);
+#elif ENGINE_MAJOR_VERSION == 4
+						bool bSaved = UPackage::SavePackage(
+							Package,
+							BP,
+							RF_Standalone,
+							*PackageFileName,
+							GError,
+							nullptr,
+							true,
+							true,
+							SAVE_None
+						);
+#endif
 						if (bSaved)
 						{
 							FKismetEditorUtilities::CompileBlueprint(BP);
@@ -685,6 +745,17 @@ FReply SFeatureBuilderWidget::OnToggleRemoteControlsComponent()
 								ULevel* CurrentLevel = EditorWorld->GetCurrentLevel();
 								UPackage* LevelPackage = CurrentLevel->GetOutermost();
 								FString LevelFilename = FPackageName::LongPackageNameToFilename(LevelPackage->GetName(), FPackageName::GetMapPackageExtension());
+#if ENGINE_MAJOR_VERSION == 5
+
+								FSavePackageArgs SaveArgs;
+								SaveArgs.TopLevelFlags = RF_Standalone;
+								SaveArgs.Error = GError;
+								SaveArgs.bWarnOfLongFilename = true;
+								SaveArgs.bForceByteSwapping = true;
+								SaveArgs.SaveFlags = SAVE_None;
+
+								bool bLevelSaved = UPackage::SavePackage(LevelPackage, nullptr, *LevelFilename, SaveArgs);
+#elif ENGINE_MAJOR_VERSION == 4
 								bool bLevelSaved = UPackage::SavePackage(
 									LevelPackage,
 									nullptr,
@@ -696,6 +767,7 @@ FReply SFeatureBuilderWidget::OnToggleRemoteControlsComponent()
 									true,
 									SAVE_None
 								);
+#endif
 								if (bLevelSaved)
 								{
 									UE_LOG(LogTemp, Log, TEXT("Level auto-saved: %s"), *LevelFilename);


### PR DESCRIPTION
# Description

* Replaces method for saving package changes in Unreal 5.6 to use argument struct. Fixes a compile issue

Height Task ID(s) (If applicable):

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned this PR to myself in GitHub
- [ ] I have assigned and notified Reviewers for this PR
